### PR TITLE
feat(worker): add traces and metrics

### DIFF
--- a/charts/sbomscanner/templates/controller/deployment.yaml
+++ b/charts/sbomscanner/templates/controller/deployment.yaml
@@ -44,6 +44,14 @@ spec:
             {{- if .Values.observability.otel.endpoint }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.observability.otel.endpoint | quote }}
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             {{- end }}
           args:
             - -leader-elect

--- a/charts/sbomscanner/templates/worker/daemonset.yaml
+++ b/charts/sbomscanner/templates/worker/daemonset.yaml
@@ -47,6 +47,18 @@ spec:
             {{- if .Values.observability.otel.endpoint }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.observability.otel.endpoint | quote }}
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             {{- end }}
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           securityContext:

--- a/charts/sbomscanner/templates/worker/daemonset.yaml
+++ b/charts/sbomscanner/templates/worker/daemonset.yaml
@@ -44,6 +44,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.observability.otel.endpoint }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.observability.otel.endpoint | quote }}
+            {{- end }}
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           securityContext:
             readOnlyRootFilesystem: true

--- a/charts/sbomscanner/templates/worker/deployment.yaml
+++ b/charts/sbomscanner/templates/worker/deployment.yaml
@@ -40,6 +40,11 @@ spec:
         - name: worker
           image: '{{ template "system_default_registry" . }}{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}'
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          {{- if .Values.observability.otel.endpoint }}
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.observability.otel.endpoint | quote }}
+          {{- end }}
           securityContext:
             {{ include "sbomscanner.securityContext" . | nindent 12 }}
           args:

--- a/charts/sbomscanner/templates/worker/deployment.yaml
+++ b/charts/sbomscanner/templates/worker/deployment.yaml
@@ -44,6 +44,14 @@ spec:
           env:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.observability.otel.endpoint | quote }}
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           {{- end }}
           securityContext:
             {{ include "sbomscanner.securityContext" . | nindent 12 }}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -26,6 +26,9 @@ import (
 	"github.com/kubewarden/sbomscanner/internal/version"
 	"github.com/kubewarden/sbomscanner/pkg/generated/clientset/versioned/scheme"
 	"github.com/nats-io/nats.go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	prombridge "go.opentelemetry.io/contrib/bridges/prometheus"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -100,7 +103,16 @@ func run(cfg config) error {
 	}()
 
 	// Initialize OpenTelemetry. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
-	shutdownTelemetry, err := telemetry.Setup(ctx, "sbomscanner-worker", version.Version)
+	// The Prometheus bridge exports the process and Go runtime metrics
+	// (process_*, go_*) over OTLP alongside our own.
+	runtimeRegistry := prometheus.NewRegistry()
+	runtimeRegistry.MustRegister(
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
+	)
+	shutdownTelemetry, err := telemetry.Setup(ctx, "sbomscanner-worker", version.Version,
+		telemetry.WithMetricProducer(prombridge.NewMetricProducer(prombridge.WithGatherer(runtimeRegistry))),
+	)
 	if err != nil {
 		return fmt.Errorf("initializing telemetry: %w", err)
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -167,19 +167,27 @@ func run(cfg config) error {
 		return registry.NewClient(transport, logger)
 	}
 
+	instrumentation, err := handlers.NewInstrumentation(
+		telemetry.Tracer("internal/handlers"),
+		telemetry.Meter("internal/handlers"),
+	)
+	if err != nil {
+		return fmt.Errorf("creating handlers instrumentation: %w", err)
+	}
+
 	var scanMode messaging.HandlerRegistry
 	durableName := "worker"
 	switch cfg.Mode {
 	case registryMode:
 		scanMode = messaging.HandlerRegistry{
-			handlers.CreateCatalogSubject: handlers.NewCreateCatalogHandler(registryClientFactory, k8sClient, scheme, publisher, cfg.InstallationNamespace, logger),
-			handlers.GenerateSBOMSubject:  handlers.NewGenerateSBOMHandler(k8sClient, scheme, cfg.RunDir, cfg.TrivyJavaDBRepository, publisher, cfg.InstallationNamespace, logger),
-			handlers.ScanSBOMSubject:      handlers.NewScanSBOMHandler(k8sClient, scheme, cfg.RunDir, cfg.TrivyDBRepository, cfg.TrivyJavaDBRepository, logger),
+			handlers.CreateCatalogSubject: handlers.NewCreateCatalogHandler(registryClientFactory, k8sClient, scheme, publisher, cfg.InstallationNamespace, instrumentation, logger),
+			handlers.GenerateSBOMSubject:  handlers.NewGenerateSBOMHandler(k8sClient, scheme, cfg.RunDir, cfg.TrivyJavaDBRepository, publisher, cfg.InstallationNamespace, instrumentation, logger),
+			handlers.ScanSBOMSubject:      handlers.NewScanSBOMHandler(k8sClient, scheme, cfg.RunDir, cfg.TrivyDBRepository, cfg.TrivyJavaDBRepository, instrumentation, logger),
 		}
 	case nodeMode:
 		scanMode = messaging.HandlerRegistry{
-			handlers.GenerateNodeSBOMSubject + "." + cfg.NodeName: handlers.NewGenerateNodeSBOMHandler(k8sClient, scheme, cfg.RunDir, targetDir, cfg.TrivyJavaDBRepository, publisher, cfg.InstallationNamespace, logger),
-			handlers.ScanNodeSBOMSubject + "." + cfg.NodeName:     handlers.NewNodeScanSBOMHandler(k8sClient, scheme, cfg.RunDir, cfg.TrivyDBRepository, cfg.TrivyJavaDBRepository, logger),
+			handlers.GenerateNodeSBOMSubject + "." + cfg.NodeName: handlers.NewGenerateNodeSBOMHandler(k8sClient, scheme, cfg.RunDir, targetDir, cfg.TrivyJavaDBRepository, publisher, cfg.InstallationNamespace, instrumentation, logger),
+			handlers.ScanNodeSBOMSubject + "." + cfg.NodeName:     handlers.NewNodeScanSBOMHandler(k8sClient, scheme, cfg.RunDir, cfg.TrivyDBRepository, cfg.TrivyJavaDBRepository, instrumentation, logger),
 		}
 		durableName = "worker-node-" + cfg.NodeName
 	default:
@@ -189,9 +197,9 @@ func run(cfg config) error {
 	var failureHandler messaging.FailureHandler
 	switch cfg.Mode {
 	case nodeMode:
-		failureHandler = handlers.NewNodeScanJobFailureHandler(k8sClient, logger)
+		failureHandler = handlers.NewNodeScanJobFailureHandler(k8sClient, instrumentation, logger)
 	default:
-		failureHandler = handlers.NewScanJobFailureHandler(k8sClient, logger)
+		failureHandler = handlers.NewScanJobFailureHandler(k8sClient, instrumentation, logger)
 	}
 	retryConfig := &messaging.RetryConfig{
 		BaseDelay:   5 * time.Second,

--- a/docs/rfc/0009_opentelemetry_instrumentation.md
+++ b/docs/rfc/0009_opentelemetry_instrumentation.md
@@ -100,6 +100,9 @@ and adopt the whole scan into its own trace.
 Reconcilers only ever read the annotation,
 so the instrumentation cannot retrigger the reconcile loops it observes.
 
+On the message hop, the trace context travels in the NATS headers instead:
+publishers inject the current traceparent and worker consumer spans parent from it.
+
 ## Metric label cardinality
 
 Every metric label value must come from a fixed, low-cardinality set known at design time.
@@ -191,32 +194,27 @@ keeps serving them for users on Prometheus pull.
 
 Traces:
 
-| Span                    | Triggered by                                                            | Key attributes                                                                                      |
-| :---------------------- | :---------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------- |
-| `Handler CreateCatalog` | NATS consume on `sbomscanner.scanjob.create-catalog`                    | `messaging.system`, `messaging.consumer.name`, `registry.host`, `scanjob.name`, `scanjob.namespace` |
-| `Handler GenerateSBOM`  | NATS consume on `sbomscanner.scanjob.generate-sbom`                     | `messaging.consumer.name`, `oci.image.ref`, `oci.image.platform`, `scanjob.name`                    |
-| `Handler ScanSBOM`      | NATS consume on `sbomscanner.scanjob.scan-sbom`                         | `messaging.consumer.name`, `oci.image.ref`, `vulnerability.count`, `vulnerability.count.critical`   |
-| `Handler ScanJobFailure` | NATS consume on the `ScanJob` failure subject                          | `messaging.consumer.name`, `scanjob.name`, `scanjob.namespace`, `error.type`                        |
-| `Handler GenerateNodeSBOM` | NATS consume on `sbomscanner.nodescanjob.generate-sbom`              | `messaging.consumer.name`, `k8s.node.name`, `nodescanjob.name`                                      |
-| `Handler NodeScanSBOM`  | NATS consume on `sbomscanner.nodescanjob.scan-sbom`                     | `messaging.consumer.name`, `k8s.node.name`, `nodescanjob.name`, `vulnerability.count`, `vulnerability.count.critical` |
-| `Handler NodeScanJobFailure` | NATS consume on the `NodeScanJob` failure subject                  | `messaging.consumer.name`, `nodescanjob.name`, `k8s.node.name`, `error.type`                        |
-| `Registry HTTP`         | `otelhttp.NewTransport` wrapping `go-containerregistry`                 | `http.method`, `http.url`, `http.status_code`, `registry.host`, `registry.operation`                |
-| `Trivy invoke`          | Each Trivy entry point call site in `generate_sbom.go` / `scan_sbom.go` / `generate_node_sbom.go` / `node_scan_sbom.go` | `trivy.command`, `trivy.target`, `trivy.db.version`, `result`                                       |
+| Span                                     | Triggered by                                                    | Key attributes                                       |
+| :---------------------------------------- | :--------------------------------------------------------------- | :---------------------------------------------------- |
+| `<Handler>.Handle`                       | Each consumed message (CreateCatalogHandler, GenerateSBOMHandler, ScanSBOMHandler, GenerateNodeSBOMHandler, NodeScanSBOMHandler) | `messaging.system=nats`, `handler.skip_reason` on the early-return paths |
+| `<Handler>.HandleFailure`                | A message exhausting its redeliveries (ScanJobFailureHandler, NodeScanJobFailureHandler) | `messaging.system=nats`, `error.message`             |
+| `Trivy.Image` / `Trivy.SBOM` / `Trivy.Filesystem` | Each Trivy invocation                                    | `trivy.command`                                       |
+
+Consumer spans (`SpanKind=Consumer`) are parented from the traceparent carried in the NATS
+message headers, injected by the publisher from the publishing context.
+Handlers publishing the next pipeline message do so inside their own span,
+so the job trace forms a tree over NATS:
+reconcile → catalog → per-image SBOM generation → scan.
 
 Metrics:
 
-| Metric                            | Type      | Labels (bounded)                                          | Exemplars                                          |
-| :-------------------------------- | :-------- | :-------------------------------------------------------- | :------------------------------------------------- |
-| `worker.scan.duration`            | Histogram | `stage` (`catalog`/`generate_sbom`/`scan_sbom`/`generate_node_sbom`/`node_scan_sbom`), `result` | `trace_id`, `scanjob.name`, `oci.image.ref`        |
-| `worker.images.scanned`           | Counter   | `registry_host`, `result`                                 | `trace_id`, `oci.image.ref`                        |
-| `worker.vulnerabilities.found`    | Counter   | `severity`, `registry_host`                               | `trace_id`, `oci.image.ref`, `vulnerability.id`    |
-| `worker.registry.call.duration`   | Histogram | `registry_host`, `operation`, `http.status_code`          | `trace_id`, `oci.image.ref`                        |
-| `worker.trivy.invoke.duration`    | Histogram | `trivy.command`, `result`                                 | `trace_id`, `trivy.target`                         |
-| `worker.handler.errors`           | Counter   | `handler`, `error.type`                                   | `trace_id`, `error.message`                        |
-| `worker.workload.vulnerabilities` | Gauge     | `owner.kind`, `owner.namespace`, `owner.name`, `severity` | `trace_id`, `workload.uid`                         |
-| `worker.workload.scans`           | Counter   | `owner.kind`, `owner.namespace`, `owner.name`, `result`   | `trace_id`, `scanjob.name`                         |
-| `worker.image.vulnerabilities`    | Gauge     | `registry_host`, `repository`, `severity`                 | `trace_id`, `oci.image.ref` (full ref with digest) |
-| `worker.image.scan.duration`      | Histogram | `registry_host`, `repository`, `result`                   | `trace_id`, `oci.image.ref`                        |
+| Metric                          | Type      | Labels (bounded)                                                                                  | Exemplars                   |
+| :------------------------------- | :-------- | :-------------------------------------------------------------------------------------------------- | :--------------------------- |
+| `worker.scan.duration`          | Histogram | `stage` (`catalog` / `generate_sbom` / `scan_sbom` / `generate_node_sbom` / `node_scan_sbom`), `result` | `trace_id`                  |
+| `sbomscanner.images.scanned`    | Counter   | `registry` (host), `result`                                                                          | `trace_id`                  |
+| `worker.registry.call.duration` | Histogram | `operation` (`catalog` / `list_repository_contents` / `get_descriptor` / `get_image_details`), `result` | `trace_id`                  |
+| `worker.trivy.duration`         | Histogram | `command` (`image` / `sbom` / `filesystem`), `result`                                                | `trace_id`                  |
+| `worker.handler.errors`         | Counter   | `handler`, `error.type` (Kubernetes status reason, `canceled`, `deadline_exceeded`, or `unknown`)    | `trace_id`                  |
 
 ### Storage
 

--- a/examples/dashboards/sbomscanner.json
+++ b/examples/dashboards/sbomscanner.json
@@ -1399,6 +1399,428 @@
         }
       ],
       "interval": "2m"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 300,
+      "panels": [],
+      "title": "Worker",
+      "type": "row"
+    },
+    {
+      "id": 301,
+      "type": "stat",
+      "title": "Scans handled",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 59
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "round(sum(histogram_count(increase(worker_scan_duration_seconds{stage=~\"catalog|generate_sbom|scan_sbom\"}[$__range])))) or vector(0)",
+          "legendFormat": "Registry",
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "B",
+          "expr": "round(sum(histogram_count(increase(worker_scan_duration_seconds{stage=~\"generate_node_sbom|node_scan_sbom\"}[$__range])))) or vector(0)",
+          "legendFormat": "Node",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 302,
+      "type": "stat",
+      "title": "Scan errors",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 59
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "round(sum(histogram_count(increase(worker_scan_duration_seconds{stage=~\"catalog|generate_sbom|scan_sbom\", result=\"error\"}[$__range])))) or vector(0)",
+          "legendFormat": "Registry",
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "B",
+          "expr": "round(sum(histogram_count(increase(worker_scan_duration_seconds{stage=~\"generate_node_sbom|node_scan_sbom\", result=\"error\"}[$__range])))) or vector(0)",
+          "legendFormat": "Node",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 304,
+      "type": "stat",
+      "title": "Trivy p95",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 59
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum(rate(worker_trivy_duration_seconds[$__range])))",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 305,
+      "type": "timeseries",
+      "title": "Scan duration p95 by stage",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 63
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (stage) (rate(worker_scan_duration_seconds[$__rate_interval])))",
+          "legendFormat": "{{stage}}"
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 306,
+      "type": "timeseries",
+      "title": "Scans handled by stage and result",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 63
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (stage, result) (histogram_count(rate(worker_scan_duration_seconds[$__rate_interval])))",
+          "legendFormat": "{{stage}}/{{result}}"
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 308,
+      "type": "timeseries",
+      "title": "Registry call p95 by operation",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 63
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (operation) (rate(worker_registry_call_duration_seconds[$__rate_interval])))",
+          "legendFormat": "{{operation}}"
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 309,
+      "type": "timeseries",
+      "title": "Images scanned by registry",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (registry) (rate(sbomscanner_images_scanned_total[$__rate_interval]))",
+          "legendFormat": "{{registry}}"
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 310,
+      "type": "timeseries",
+      "title": "Handler errors by type",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 71
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (handler, error_type) (rate(worker_handler_errors_total[$__rate_interval]))",
+          "legendFormat": "{{handler}}/{{error_type}}"
+        }
+      ],
+      "interval": "2m"
     }
   ],
   "refresh": "10s",

--- a/examples/dashboards/sbomscanner.json
+++ b/examples/dashboards/sbomscanner.json
@@ -347,7 +347,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 5
       },
@@ -395,8 +395,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 6,
         "y": 5
       },
       "fieldConfig": {
@@ -443,8 +443,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 12,
         "y": 5
       },
       "fieldConfig": {
@@ -1347,7 +1347,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "process_resident_memory_bytes",
+          "expr": "process_resident_memory_bytes{job=\"sbomscanner-controller\"}",
           "legendFormat": "resident"
         }
       ]
@@ -1394,7 +1394,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "rate(process_cpu_seconds_total[$__rate_interval])",
+          "expr": "rate(process_cpu_seconds_total{job=\"sbomscanner-controller\"}[$__rate_interval])",
           "legendFormat": "cpu"
         }
       ],
@@ -1818,6 +1818,101 @@
           "refId": "A",
           "expr": "sum by (handler, error_type) (rate(worker_handler_errors_total[$__rate_interval]))",
           "legendFormat": "{{handler}}/{{error_type}}"
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 311,
+      "type": "timeseries",
+      "title": "Memory (RSS)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 71
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "process_resident_memory_bytes{job=\"sbomscanner-worker\"}",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 312,
+      "type": "timeseries",
+      "title": "CPU",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 71
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(process_cpu_seconds_total{job=\"sbomscanner-worker\"}[$__rate_interval])",
+          "legendFormat": "{{instance}}"
         }
       ],
       "interval": "2m"

--- a/go.mod
+++ b/go.mod
@@ -358,7 +358,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
+	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect

--- a/internal/handlers/create_catalog.go
+++ b/internal/handlers/create_catalog.go
@@ -45,6 +45,7 @@ type CreateCatalogHandler struct {
 	scheme                *runtime.Scheme
 	publisher             messaging.Publisher
 	installationNamespace string
+	instrumentation       *Instrumentation
 	logger                *slog.Logger
 }
 
@@ -55,16 +56,18 @@ func NewCreateCatalogHandler(
 	scheme *runtime.Scheme,
 	publisher messaging.Publisher,
 	installationNamespace string,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
-) *CreateCatalogHandler {
-	return &CreateCatalogHandler{
+) *InstrumentedHandler {
+	return instrumentHandler(instrumentation, "CreateCatalogHandler", "catalog", &CreateCatalogHandler{
 		registryClientFactory: registryClientFactory,
 		k8sClient:             k8sClient,
 		publisher:             publisher,
 		scheme:                scheme,
 		installationNamespace: installationNamespace,
+		instrumentation:       instrumentation,
 		logger:                logger.With("handler", "create_catalog_handler"),
-	}
+	})
 }
 
 // Handle processes the create catalog message and creates Image resources.
@@ -105,6 +108,7 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message messaging.Mes
 		if apierrors.IsNotFound(err) {
 			// Stop processing if the scanjob is not found, since it might have been deleted.
 			h.logger.InfoContext(ctx, "ScanJob not found, stopping catalog creation", "scanjob", createCatalogMessage.ScanJob.Name, "namespace", createCatalogMessage.ScanJob.Namespace)
+			recordSpanSkipReason(ctx, skipReasonJobNotFound)
 			return nil
 		}
 		return fmt.Errorf("cannot update scan job status %s/%s: %w", createCatalogMessage.ScanJob.Namespace, createCatalogMessage.ScanJob.Name, err)
@@ -226,6 +230,7 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message messaging.Mes
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					h.logger.InfoContext(ctx, "ScanJob not found, stopping catalog creation", "scanjob", createCatalogMessage.ScanJob.Name, "namespace", createCatalogMessage.ScanJob.Namespace)
+					recordSpanSkipReason(ctx, skipReasonJobNotFound)
 					return nil
 				}
 				return fmt.Errorf("cannot get scanjob %s/%s: %w", createCatalogMessage.ScanJob.Namespace, createCatalogMessage.ScanJob.Name, err)
@@ -233,6 +238,7 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message messaging.Mes
 			if string(scanJob.GetUID()) != createCatalogMessage.ScanJob.UID {
 				h.logger.InfoContext(ctx, "ScanJob not found, stopping SBOM generation (UID changed)", "scanjob", createCatalogMessage.ScanJob.Name, "namespace", createCatalogMessage.ScanJob.Namespace,
 					"uid", createCatalogMessage.ScanJob.UID)
+				recordSpanSkipReason(ctx, skipReasonUIDMismatch)
 				return nil
 			}
 
@@ -349,7 +355,9 @@ func (h *CreateCatalogHandler) discoverRepositories(
 	// In this case, we need to discover all the repositories in the registry.
 	if len(registry.Spec.Repositories) == 0 {
 		var allRepositories []string
+		catalogDone := h.instrumentation.startRegistryCall(ctx, "catalog")
 		allRepositories, err = registryClient.Catalog(ctx, reg)
+		catalogDone(err)
 		if err != nil {
 			return []string{}, fmt.Errorf("cannot discover repositories: %w", err)
 		}
@@ -377,7 +385,9 @@ func (h *CreateCatalogHandler) discoverImages(
 		return []string{}, fmt.Errorf("cannot parse repository name %q: %w", repository, err)
 	}
 
+	listDone := h.instrumentation.startRegistryCall(ctx, "list_repository_contents")
 	contents, err := registryClient.ListRepositoryContents(ctx, repo)
+	listDone(err)
 	if err != nil {
 		return []string{}, fmt.Errorf("cannot list repository contents: %w", err)
 	}
@@ -394,7 +404,9 @@ func (h *CreateCatalogHandler) refToImages(
 	ref name.Reference,
 	registry *v1alpha1.Registry,
 ) ([]storagev1alpha1.Image, error) {
+	descriptorDone := h.instrumentation.startRegistryCall(ctx, "get_descriptor")
 	desc, err := registryClient.GetDescriptor(ctx, ref)
+	descriptorDone(err)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get descriptor for %q: %w", ref.Name(), err)
 	}
@@ -427,7 +439,9 @@ func (h *CreateCatalogHandler) singleArchRefToImages(
 	ref name.Reference,
 	registry *v1alpha1.Registry,
 ) ([]storagev1alpha1.Image, error) {
+	detailsDone := h.instrumentation.startRegistryCall(ctx, "get_image_details")
 	imageDetails, err := registryClient.GetImageDetails(ctx, ref, nil)
+	detailsDone(err)
 	if err != nil {
 		return []storagev1alpha1.Image{}, fmt.Errorf("cannot get image details for %q: %w", ref.Name(), err)
 	}
@@ -486,7 +500,9 @@ func (h *CreateCatalogHandler) multiArchRefToImages(
 			continue
 		}
 
+		indexDetailsDone := h.instrumentation.startRegistryCall(ctx, "get_image_details")
 		imageDetails, err := registryClient.GetImageDetailsFromIndex(ctx, imageIndex, m.Digest, m.Platform)
+		indexDetailsDone(err)
 		if err != nil {
 			return nil, fmt.Errorf("cannot get image details for %q digest %s platform %v: %w", ref.Name(), m.Digest, m.Platform, err)
 		}

--- a/internal/handlers/create_catalog_test.go
+++ b/internal/handlers/create_catalog_test.go
@@ -550,7 +550,7 @@ func TestCreateCatalogHandler_Handle(t *testing.T) {
 				mockPublisher.On("Publish", mock.Anything, GenerateSBOMSubject, messageID, expectedMessage).Return(nil).Once()
 			}
 
-			handler := NewCreateCatalogHandler(registryClientFactory, k8sClient, scheme, mockPublisher, "sbomscanner", slog.Default())
+			handler := NewCreateCatalogHandler(registryClientFactory, k8sClient, scheme, mockPublisher, "sbomscanner", newNoopInstrumentation(), slog.Default())
 
 			message, err := json.Marshal(&CreateCatalogMessage{
 				BaseMessage: BaseMessage{
@@ -794,7 +794,7 @@ func TestCreateCatalogHandler_Handle_StopProcessing(t *testing.T) {
 
 			mockPublisher := messagingMocks.NewMockPublisher(t)
 
-			handler := NewCreateCatalogHandler(registryClient, k8sClientWithInterceptors, scheme, mockPublisher, "sbomscanner", slog.Default())
+			handler := NewCreateCatalogHandler(registryClient, k8sClientWithInterceptors, scheme, mockPublisher, "sbomscanner", newNoopInstrumentation(), slog.Default())
 
 			message, err := json.Marshal(&CreateCatalogMessage{
 				BaseMessage: BaseMessage{

--- a/internal/handlers/generate_node_sbom.go
+++ b/internal/handlers/generate_node_sbom.go
@@ -36,6 +36,7 @@ type GenerateNodeSBOMHandler struct {
 	trivyJavaDBRepository string
 	publisher             messaging.Publisher
 	installationNamespace string
+	instrumentation       *Instrumentation
 	logger                *slog.Logger
 }
 
@@ -48,9 +49,10 @@ func NewGenerateNodeSBOMHandler(
 	trivyJavaDBRepository string,
 	publisher messaging.Publisher,
 	installationNamespace string,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
-) *GenerateNodeSBOMHandler {
-	return &GenerateNodeSBOMHandler{
+) *InstrumentedHandler {
+	return instrumentHandler(instrumentation, "GenerateNodeSBOMHandler", "generate_node_sbom", &GenerateNodeSBOMHandler{
 		k8sClient:             k8sClient,
 		scheme:                scheme,
 		workDir:               workDir,
@@ -58,8 +60,9 @@ func NewGenerateNodeSBOMHandler(
 		trivyJavaDBRepository: trivyJavaDBRepository,
 		publisher:             publisher,
 		installationNamespace: installationNamespace,
+		instrumentation:       instrumentation,
 		logger:                logger.With("handler", "generate_node_sbom_handler"),
-	}
+	})
 }
 
 // Handle processes the GenerateNodeSBOMMessage and generates a SBOM resource from the specified image.
@@ -83,6 +86,7 @@ func (h *GenerateNodeSBOMHandler) Handle(ctx context.Context, message messaging.
 		// Stop processing if the scanjob is not found, since it might have been deleted.
 		if apierrors.IsNotFound(err) {
 			h.logger.InfoContext(ctx, "NodeScanJob not found, stopping NodeSBOM generation", "nodescanjob", generateNodeSBOMMessage.NodeScanJob.Name)
+			recordSpanSkipReason(ctx, skipReasonJobNotFound)
 			return nil
 		}
 
@@ -91,6 +95,7 @@ func (h *GenerateNodeSBOMHandler) Handle(ctx context.Context, message messaging.
 	if nodeScanJob.Name != generateNodeSBOMMessage.NodeScanJob.Name {
 		h.logger.InfoContext(ctx, "NodeScanJob not found, stopping NodeSBOM generation", "nodescanjob", generateNodeSBOMMessage.NodeScanJob.Name,
 			"uid", generateNodeSBOMMessage.NodeScanJob.UID)
+		recordSpanSkipReason(ctx, skipReasonUIDMismatch)
 		return nil
 	}
 
@@ -102,6 +107,7 @@ func (h *GenerateNodeSBOMHandler) Handle(ctx context.Context, message messaging.
 		// Stop processing if the node is not found, since it might have been deleted.
 		if apierrors.IsNotFound(err) {
 			h.logger.InfoContext(ctx, "Node not found, stopping NodeSBOM generation", "node", generateNodeSBOMMessage.Node.Name)
+			recordSpanSkipReason(ctx, skipReasonObjectNotFound)
 			return nil
 		}
 
@@ -111,6 +117,7 @@ func (h *GenerateNodeSBOMHandler) Handle(ctx context.Context, message messaging.
 
 	if nodeScanJob.IsFailed() {
 		h.logger.InfoContext(ctx, "NodeScanJob is in failed state, stopping NodeSBOM generation", "nodescanjob", nodeScanJob.Name)
+		recordSpanSkipReason(ctx, skipReasonJobFailed)
 		return nil
 	}
 
@@ -128,6 +135,7 @@ func (h *GenerateNodeSBOMHandler) Handle(ctx context.Context, message messaging.
 		// The NodeScanJob may have been deleted while we were processing; abandon the update.
 		if apierrors.IsNotFound(err) {
 			h.logger.InfoContext(ctx, "NodeScanJob not found, stopping NodeSBOM generation", "nodescanjob", generateNodeSBOMMessage.NodeScanJob.Name)
+			recordSpanSkipReason(ctx, skipReasonJobNotFound)
 			return nil
 		}
 		return fmt.Errorf("failed to update NodeScanJob status to in progress: %w", err)
@@ -144,6 +152,7 @@ func (h *GenerateNodeSBOMHandler) Handle(ctx context.Context, message messaging.
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			h.logger.InfoContext(ctx, "NodeScanConfiguration not found, stopping NodeSBOM generation", "node name", node.Name)
+			recordSpanSkipReason(ctx, skipReasonObjectNotFound)
 			return nil
 		}
 		return fmt.Errorf("cannot get NodeScanConfiguration: %w", err)
@@ -200,6 +209,7 @@ func (h *GenerateNodeSBOMHandler) Handle(ctx context.Context, message messaging.
 	if err = h.k8sClient.Get(ctx, client.ObjectKey{Name: generateNodeSBOMMessage.NodeScanJob.Name}, &v1alpha1.NodeScanJob{}); err != nil {
 		if apierrors.IsNotFound(err) {
 			h.logger.InfoContext(ctx, "NodeScanJob no longer exists, skipping publish of scan NodeSBOM message", "nodescanjob", generateNodeSBOMMessage.NodeScanJob.Name)
+			recordSpanSkipReason(ctx, skipReasonJobNotFound)
 			return nil
 		}
 		return fmt.Errorf("cannot get NodeScanJob %s: %w", generateNodeSBOMMessage.NodeScanJob.Name, err)
@@ -294,7 +304,10 @@ func (h *GenerateNodeSBOMHandler) generateSPDX(ctx context.Context, skipPats []s
 
 	h.logger.DebugContext(ctx, "Executing Trivy to generate SPDX SBOM", "args", args)
 
-	if err = app.ExecuteContext(ctx); err != nil {
+	trivyCtx, trivyDone := h.instrumentation.startTrivy(ctx, trivyCommandFilesystem)
+	err = app.ExecuteContext(trivyCtx)
+	trivyDone(err)
+	if err != nil {
 		return nil, fmt.Errorf("failed to execute trivy: %w", err)
 	}
 

--- a/internal/handlers/generate_node_sbom_test.go
+++ b/internal/handlers/generate_node_sbom_test.go
@@ -107,7 +107,7 @@ func TestGenerateNodeSBOMHandler_Handle(t *testing.T) {
 		expectedScanMessage,
 	).Return(nil).Once()
 
-	handler := NewGenerateNodeSBOMHandler(k8sClient, scheme, t.TempDir(), targetDir, testTrivyJavaDBRepository, publisher, "sbomscanner", slog.Default())
+	handler := NewGenerateNodeSBOMHandler(k8sClient, scheme, t.TempDir(), targetDir, testTrivyJavaDBRepository, publisher, "sbomscanner", newNoopInstrumentation(), slog.Default())
 
 	message, err := json.Marshal(&GenerateNodeSBOMMessage{
 		NodeBaseMessage: NodeBaseMessage{
@@ -229,7 +229,7 @@ func TestGenerateNodeSBOMHandler_Handle_StopProcessing(t *testing.T) {
 
 			publisher := messagingMocks.NewMockPublisher(t)
 
-			handler := NewGenerateNodeSBOMHandler(k8sClient, scheme, t.TempDir(), "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", slog.Default())
+			handler := NewGenerateNodeSBOMHandler(k8sClient, scheme, t.TempDir(), "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", newNoopInstrumentation(), slog.Default())
 
 			message, err := json.Marshal(&GenerateNodeSBOMMessage{
 				NodeBaseMessage: NodeBaseMessage{

--- a/internal/handlers/generate_sbom.go
+++ b/internal/handlers/generate_sbom.go
@@ -32,6 +32,7 @@ type GenerateSBOMHandler struct {
 	trivyJavaDBRepository string
 	publisher             messaging.Publisher
 	installationNamespace string
+	instrumentation       *Instrumentation
 	logger                *slog.Logger
 }
 
@@ -43,20 +44,24 @@ func NewGenerateSBOMHandler(
 	trivyJavaDBRepository string,
 	publisher messaging.Publisher,
 	installationNamespace string,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
-) *GenerateSBOMHandler {
-	return &GenerateSBOMHandler{
+) *InstrumentedHandler {
+	return instrumentHandler(instrumentation, "GenerateSBOMHandler", "generate_sbom", &GenerateSBOMHandler{
 		k8sClient:             k8sClient,
 		scheme:                scheme,
 		workDir:               workDir,
 		trivyJavaDBRepository: trivyJavaDBRepository,
 		publisher:             publisher,
 		installationNamespace: installationNamespace,
+		instrumentation:       instrumentation,
 		logger:                logger.With("handler", "generate_sbom_handler"),
-	}
+	})
 }
 
 // Handle processes the GenerateSBOMMessage and generates a SBOM resource from the specified image.
+//
+//nolint:funlen
 func (h *GenerateSBOMHandler) Handle(ctx context.Context, message messaging.Message) error {
 	generateSBOMMessage := &GenerateSBOMMessage{}
 	if err := json.Unmarshal(message.Data(), generateSBOMMessage); err != nil {
@@ -77,6 +82,7 @@ func (h *GenerateSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 		// Stop processing if the scanjob is not found, since it might have been deleted.
 		if apierrors.IsNotFound(err) {
 			h.logger.InfoContext(ctx, "ScanJob not found, stopping SBOM generation", "scanjob", generateSBOMMessage.ScanJob.Name, "namespace", generateSBOMMessage.ScanJob.Namespace)
+			recordSpanSkipReason(ctx, skipReasonJobNotFound)
 			return nil
 		}
 
@@ -85,6 +91,7 @@ func (h *GenerateSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 	if string(scanJob.GetUID()) != generateSBOMMessage.ScanJob.UID {
 		h.logger.InfoContext(ctx, "ScanJob not found, stopping SBOM generation (UID changed)", "scanjob", generateSBOMMessage.ScanJob.Name, "namespace", generateSBOMMessage.ScanJob.Namespace,
 			"uid", generateSBOMMessage.ScanJob.UID)
+		recordSpanSkipReason(ctx, skipReasonUIDMismatch)
 		return nil
 	}
 
@@ -92,6 +99,7 @@ func (h *GenerateSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 
 	if scanJob.IsFailed() {
 		h.logger.InfoContext(ctx, "ScanJob is in failed state, stopping SBOM generation", "scanjob", scanJob.Name, "namespace", scanJob.Namespace)
+		recordSpanSkipReason(ctx, skipReasonJobFailed)
 		return nil
 	}
 
@@ -104,6 +112,7 @@ func (h *GenerateSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 		// Stop processing if the image is not found, since it might have been deleted.
 		if apierrors.IsNotFound(err) {
 			h.logger.InfoContext(ctx, "Image not found, stopping SBOM generation", "image", generateSBOMMessage.Image.Name, "namespace", generateSBOMMessage.Image.Namespace)
+			recordSpanSkipReason(ctx, skipReasonObjectNotFound)
 			return nil
 		}
 
@@ -319,7 +328,10 @@ func (h *GenerateSBOMHandler) generateSPDX(ctx context.Context, image *storagev1
 	app := trivyCommands.NewApp()
 	app.SetArgs(args)
 
-	if err = app.ExecuteContext(ctx); err != nil {
+	trivyCtx, trivyDone := h.instrumentation.startTrivy(ctx, trivyCommandImage)
+	err = app.ExecuteContext(trivyCtx)
+	trivyDone(err)
+	if err != nil {
 		return nil, fmt.Errorf("failed to execute trivy: %w", err)
 	}
 

--- a/internal/handlers/generate_sbom_test.go
+++ b/internal/handlers/generate_sbom_test.go
@@ -177,7 +177,7 @@ func testGenerateSBOM(t *testing.T, platform, sha256, expectedSPDXJSON string) {
 		expectedScanMessage,
 	).Return(nil).Once()
 
-	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", slog.Default())
+	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", newNoopInstrumentation(), slog.Default())
 
 	message, err := json.Marshal(&GenerateSBOMMessage{
 		BaseMessage: BaseMessage{
@@ -331,7 +331,7 @@ func TestGenerateSBOMHandler_Handle_ReuseSBOMWithSameDigest(t *testing.T) {
 		expectedScanMessage,
 	).Return(nil).Once()
 
-	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", slog.Default())
+	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", newNoopInstrumentation(), slog.Default())
 
 	message, err := json.Marshal(&GenerateSBOMMessage{
 		BaseMessage: BaseMessage{
@@ -460,7 +460,7 @@ func TestGenerateSBOMHandler_Handle_StopProcessing(t *testing.T) {
 			publisher := messagingMocks.NewMockPublisher(t)
 			// Publisher should not be called since we exit early
 
-			handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", slog.Default())
+			handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", newNoopInstrumentation(), slog.Default())
 
 			message, err := json.Marshal(&GenerateSBOMMessage{
 				BaseMessage: BaseMessage{
@@ -585,7 +585,7 @@ func TestGenerateSBOMHandler_Handle_ExistingSBOM(t *testing.T) {
 		expectedScanMessage,
 	).Return(nil).Once()
 
-	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", slog.Default())
+	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", newNoopInstrumentation(), slog.Default())
 
 	message, err := json.Marshal(&GenerateSBOMMessage{
 		BaseMessage: BaseMessage{
@@ -723,7 +723,7 @@ func TestGenerateSBOMHandler_Handle_PrivateRegistry(t *testing.T) {
 		expectedScanMessage,
 	).Return(nil).Once()
 
-	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", slog.Default())
+	handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", newNoopInstrumentation(), slog.Default())
 
 	message, err := json.Marshal(&GenerateSBOMMessage{
 		BaseMessage: BaseMessage{
@@ -896,7 +896,7 @@ func TestGenerateSBOMHandler_Handle_Certificates(t *testing.T) {
 				expectedScanMessage,
 			).Return(nil).Once()
 
-			handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", slog.Default())
+			handler := NewGenerateSBOMHandler(k8sClient, scheme, "/tmp", testTrivyJavaDBRepository, publisher, "sbomscanner", newNoopInstrumentation(), slog.Default())
 
 			message, err := json.Marshal(&GenerateSBOMMessage{
 				BaseMessage: BaseMessage{

--- a/internal/handlers/instrumentation.go
+++ b/internal/handlers/instrumentation.go
@@ -1,0 +1,285 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubewarden/sbomscanner/internal/messaging"
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
+)
+
+// Bounded result label values.
+const (
+	resultSuccess = "success"
+	resultError   = "error"
+)
+
+// Bounded handler.skip_reason span attribute values, set on the early-return paths.
+const (
+	skipReasonJobNotFound    = "job_not_found"
+	skipReasonUIDMismatch    = "uid_mismatch"
+	skipReasonJobFailed      = "job_failed"
+	skipReasonObjectNotFound = "object_not_found"
+)
+
+// Trivy subcommands used by the handlers.
+const (
+	trivyCommandImage      = "image"
+	trivyCommandSBOM       = "sbom"
+	trivyCommandFilesystem = "filesystem"
+)
+
+// Instrumentation bundles the tracer and the metric instruments shared by the worker handlers.
+// Disabled telemetry is represented by no-op providers.
+type Instrumentation struct {
+	tracer               trace.Tracer
+	scanDuration         metric.Float64Histogram
+	imagesScanned        metric.Int64Counter
+	registryCallDuration metric.Float64Histogram
+	trivyDuration        metric.Float64Histogram
+	handlerErrors        metric.Int64Counter
+}
+
+// NewInstrumentation creates a new Instrumentation.
+func NewInstrumentation(tracer trace.Tracer, meter metric.Meter) (*Instrumentation, error) {
+	scanDuration, err := meter.Float64Histogram(
+		"worker.scan.duration",
+		metric.WithDescription("Duration of one handled scan stage."),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating worker.scan.duration histogram: %w", err)
+	}
+
+	imagesScanned, err := meter.Int64Counter(
+		"sbomscanner.images.scanned",
+		metric.WithDescription("Number of images scanned."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating sbomscanner.images.scanned counter: %w", err)
+	}
+
+	registryCallDuration, err := meter.Float64Histogram(
+		"worker.registry.call.duration",
+		metric.WithDescription("Duration of registry calls."),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating worker.registry.call.duration histogram: %w", err)
+	}
+
+	trivyDuration, err := meter.Float64Histogram(
+		"worker.trivy.duration",
+		metric.WithDescription("Duration of Trivy invocations."),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating worker.trivy.duration histogram: %w", err)
+	}
+
+	handlerErrors, err := meter.Int64Counter(
+		"worker.handler.errors",
+		metric.WithDescription("Number of handler errors."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating worker.handler.errors counter: %w", err)
+	}
+
+	return &Instrumentation{
+		tracer:               tracer,
+		scanDuration:         scanDuration,
+		imagesScanned:        imagesScanned,
+		registryCallDuration: registryCallDuration,
+		trivyDuration:        trivyDuration,
+		handlerErrors:        handlerErrors,
+	}, nil
+}
+
+// recordHandled records the duration of one handled message, and counts the error when it failed.
+func (i *Instrumentation) recordHandled(ctx context.Context, stage string, elapsed time.Duration, err error) {
+	result := resultSuccess
+	if err != nil {
+		result = resultError
+		i.handlerErrors.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("handler", stage),
+			attribute.String("error.type", errorType(err)),
+		))
+	}
+	i.scanDuration.Record(ctx, elapsed.Seconds(), metric.WithAttributes(
+		attribute.String("stage", stage),
+		attribute.String("result", result),
+	))
+}
+
+// recordImageScanned counts one scanned image with the given registry host and scan outcome.
+func (i *Instrumentation) recordImageScanned(ctx context.Context, registryHost string, err error) {
+	result := resultSuccess
+	if err != nil {
+		result = resultError
+	}
+	i.imagesScanned.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("registry", registryHost),
+		attribute.String("result", result),
+	))
+}
+
+// startTrivy starts a span for one Trivy invocation and returns a done function
+// that records its duration and outcome.
+//
+//nolint:spancheck // The span is ended by the returned done function.
+func (i *Instrumentation) startTrivy(ctx context.Context, command string) (context.Context, func(error)) {
+	ctx, span := i.tracer.Start(ctx, trivySpanName(command),
+		trace.WithAttributes(attribute.String("trivy.command", command)),
+	)
+	start := time.Now()
+
+	return ctx, func(err error) {
+		result := resultSuccess
+		if err != nil {
+			result = resultError
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		i.trivyDuration.Record(ctx, time.Since(start).Seconds(), metric.WithAttributes(
+			attribute.String("command", command),
+			attribute.String("result", result),
+		))
+		span.End()
+	}
+}
+
+// startRegistryCall returns a done function recording the duration and outcome of one registry call.
+func (i *Instrumentation) startRegistryCall(ctx context.Context, operation string) func(error) {
+	start := time.Now()
+
+	return func(err error) {
+		result := resultSuccess
+		if err != nil {
+			result = resultError
+		}
+		i.registryCallDuration.Record(ctx, time.Since(start).Seconds(), metric.WithAttributes(
+			attribute.String("operation", operation),
+			attribute.String("result", result),
+		))
+	}
+}
+
+// instrumentHandler wraps inner with a consumer span and metrics per handled message.
+func instrumentHandler(instrumentation *Instrumentation, name, stage string, inner messaging.Handler) *InstrumentedHandler {
+	return &InstrumentedHandler{
+		inner:           inner,
+		instrumentation: instrumentation,
+		spanName:        name + ".Handle",
+		stage:           stage,
+	}
+}
+
+// InstrumentedHandler decorates a messaging.Handler with a span and metrics per message.
+type InstrumentedHandler struct {
+	inner           messaging.Handler
+	instrumentation *Instrumentation
+	spanName        string
+	stage           string
+}
+
+// Handle implements messaging.Handler.
+func (h *InstrumentedHandler) Handle(ctx context.Context, message messaging.Message) error {
+	ctx = telemetry.ExtractNATS(ctx, message.Headers())
+	ctx, span := h.instrumentation.tracer.Start(ctx, h.spanName,
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithAttributes(attribute.String("messaging.system", "nats")),
+	)
+	defer span.End()
+
+	start := time.Now()
+	err := h.inner.Handle(ctx, message)
+	h.instrumentation.recordHandled(ctx, h.stage, time.Since(start), err)
+
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+
+	//nolint:wrapcheck // Pass-through decorator: the inner handler's error must reach the subscriber unwrapped.
+	return err
+}
+
+// instrumentFailureHandler wraps inner with a consumer span per failed message.
+func instrumentFailureHandler(instrumentation *Instrumentation, name string, inner messaging.FailureHandler) *InstrumentedFailureHandler {
+	return &InstrumentedFailureHandler{
+		inner:           inner,
+		instrumentation: instrumentation,
+		spanName:        name + ".HandleFailure",
+	}
+}
+
+// InstrumentedFailureHandler decorates a messaging.FailureHandler with a span per failed message.
+type InstrumentedFailureHandler struct {
+	inner           messaging.FailureHandler
+	instrumentation *Instrumentation
+	spanName        string
+}
+
+// HandleFailure implements messaging.FailureHandler.
+func (h *InstrumentedFailureHandler) HandleFailure(ctx context.Context, message messaging.Message, errorMessage string) error {
+	ctx = telemetry.ExtractNATS(ctx, message.Headers())
+	ctx, span := h.instrumentation.tracer.Start(ctx, h.spanName,
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "nats"),
+			attribute.String("error.message", errorMessage),
+		),
+	)
+	defer span.End()
+
+	err := h.inner.HandleFailure(ctx, message, errorMessage)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+
+	//nolint:wrapcheck // Pass-through decorator: the inner handler's error must reach the subscriber unwrapped.
+	return err
+}
+
+// recordSpanSkipReason records on the current span why a handler skipped processing.
+func recordSpanSkipReason(ctx context.Context, reason string) {
+	trace.SpanFromContext(ctx).SetAttributes(attribute.String("handler.skip_reason", reason))
+}
+
+// trivySpanName maps a Trivy subcommand to its span name.
+func trivySpanName(command string) string {
+	switch command {
+	case trivyCommandImage:
+		return "Trivy.Image"
+	case trivyCommandSBOM:
+		return "Trivy.SBOM"
+	case trivyCommandFilesystem:
+		return "Trivy.Filesystem"
+	default:
+		return "Trivy.Unknown"
+	}
+}
+
+// errorType maps a handler error to a bounded metric label value.
+func errorType(err error) string {
+	if reason := apierrors.ReasonForError(err); reason != metav1.StatusReasonUnknown {
+		return string(reason)
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	}
+	return "unknown"
+}

--- a/internal/handlers/instrumentation_test.go
+++ b/internal/handlers/instrumentation_test.go
@@ -1,0 +1,238 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kubewarden/sbomscanner/internal/messaging"
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
+)
+
+// fakeHandler returns a fixed error so tests can drive success and failure outcomes.
+type fakeHandler struct {
+	err error
+}
+
+func (f *fakeHandler) Handle(context.Context, messaging.Message) error {
+	return f.err
+}
+
+// fakeFailureHandler returns a fixed error so tests can drive success and failure outcomes.
+type fakeFailureHandler struct {
+	err error
+}
+
+func (f *fakeFailureHandler) HandleFailure(context.Context, messaging.Message, string) error {
+	return f.err
+}
+
+// newTestInstrumentation builds an Instrumentation backed by in-memory SDK providers,
+// returning the span recorder and metric reader used for assertions.
+func newTestInstrumentation(t *testing.T) (*Instrumentation, *tracetest.SpanRecorder, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() { _ = tracerProvider.Shutdown(context.Background()) })
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = meterProvider.Shutdown(context.Background()) })
+
+	instrumentation, err := NewInstrumentation(tracerProvider.Tracer("test"), meterProvider.Meter("test"))
+	require.NoError(t, err)
+
+	return instrumentation, spanRecorder, reader
+}
+
+// publishedMessage returns a message carrying the traceparent of a fresh publishing span,
+// along with that span's context.
+func publishedMessage(t *testing.T, instrumentation *Instrumentation) (*testMessage, trace.SpanContext) {
+	t.Helper()
+
+	publishCtx, publishSpan := instrumentation.tracer.Start(context.Background(), "publish")
+	publishSpan.End()
+
+	msg := &nats.Msg{Header: nats.Header{}}
+	telemetry.InjectNATS(publishCtx, msg)
+	require.NotEmpty(t, msg.Header.Get("traceparent"))
+
+	return &testMessage{headers: msg.Header}, publishSpan.SpanContext()
+}
+
+// TestInstrumentHandler_JoinsPublisherTrace asserts that the consumer span is parented into the
+// trace carried by the message headers, forming the job tree over NATS.
+func TestInstrumentHandler_JoinsPublisherTrace(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	instrumentation, spanRecorder, reader := newTestInstrumentation(t)
+
+	message, publishSpanContext := publishedMessage(t, instrumentation)
+	handler := instrumentHandler(instrumentation, "CreateCatalogHandler", "catalog", &fakeHandler{})
+
+	require.NoError(t, handler.Handle(context.Background(), message))
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 2)
+	span := spans[1]
+	assert.Equal(t, "CreateCatalogHandler.Handle", span.Name())
+	assert.Equal(t, trace.SpanKindConsumer, span.SpanKind())
+	assert.Equal(t, publishSpanContext.TraceID(), span.SpanContext().TraceID(),
+		"the consumer span must belong to the publishing trace")
+	assert.Equal(t, publishSpanContext.SpanID(), span.Parent().SpanID())
+	attrs := attribute.NewSet(span.Attributes()...)
+	assert.Equal(t, "nats", attrValue(attrs, "messaging.system"))
+
+	points := collectDataPoints(t, reader, "worker.scan.duration")
+	require.Len(t, points, 1)
+	assert.Equal(t, "catalog", attrValue(points[0], "stage"))
+	assert.Equal(t, "success", attrValue(points[0], "result"))
+}
+
+// TestInstrumentHandler_Error asserts the error is recorded on the span,
+// the duration, and the errors counter with a bounded error type.
+func TestInstrumentHandler_Error(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	instrumentation, spanRecorder, reader := newTestInstrumentation(t)
+
+	notFound := apierrors.NewNotFound(schema.GroupResource{Resource: "scanjobs"}, "my-job")
+	handler := instrumentHandler(instrumentation, "ScanSBOMHandler", "scan_sbom", &fakeHandler{err: notFound})
+
+	require.Error(t, handler.Handle(context.Background(), &testMessage{}))
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+	require.Len(t, spans[0].Events(), 1, "the error must be recorded on the span")
+
+	durations := collectDataPoints(t, reader, "worker.scan.duration")
+	require.Len(t, durations, 1)
+	assert.Equal(t, "error", attrValue(durations[0], "result"))
+
+	errorsPoints := collectDataPoints(t, reader, "worker.handler.errors")
+	require.Len(t, errorsPoints, 1)
+	assert.Equal(t, "scan_sbom", attrValue(errorsPoints[0], "handler"))
+	assert.Equal(t, "NotFound", attrValue(errorsPoints[0], "error.type"))
+}
+
+// TestInstrumentFailureHandler asserts the failure span joins the message trace.
+func TestInstrumentFailureHandler(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	instrumentation, spanRecorder, _ := newTestInstrumentation(t)
+
+	message, publishSpanContext := publishedMessage(t, instrumentation)
+	handler := instrumentFailureHandler(instrumentation, "ScanJobFailureHandler", &fakeFailureHandler{})
+
+	require.NoError(t, handler.HandleFailure(context.Background(), message, "boom"))
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 2)
+	span := spans[1]
+	assert.Equal(t, "ScanJobFailureHandler.HandleFailure", span.Name())
+	assert.Equal(t, publishSpanContext.TraceID(), span.SpanContext().TraceID())
+	attrs := attribute.NewSet(span.Attributes()...)
+	assert.Equal(t, "boom", attrValue(attrs, "error.message"))
+}
+
+// TestStartTrivy asserts the Trivy span shape and the duration metric labels.
+func TestStartTrivy(t *testing.T) {
+	instrumentation, spanRecorder, reader := newTestInstrumentation(t)
+
+	_, done := instrumentation.startTrivy(context.Background(), trivyCommandSBOM)
+	done(assert.AnError)
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "Trivy.SBOM", spans[0].Name())
+	attrs := attribute.NewSet(spans[0].Attributes()...)
+	assert.Equal(t, "sbom", attrValue(attrs, "trivy.command"))
+
+	points := collectDataPoints(t, reader, "worker.trivy.duration")
+	require.Len(t, points, 1)
+	assert.Equal(t, "sbom", attrValue(points[0], "command"))
+	assert.Equal(t, "error", attrValue(points[0], "result"))
+}
+
+// TestStartRegistryCall asserts the duration metric labels.
+func TestStartRegistryCall(t *testing.T) {
+	instrumentation, _, reader := newTestInstrumentation(t)
+
+	done := instrumentation.startRegistryCall(context.Background(), "catalog")
+	done(assert.AnError)
+
+	points := collectDataPoints(t, reader, "worker.registry.call.duration")
+	require.Len(t, points, 1)
+	assert.Equal(t, "catalog", attrValue(points[0], "operation"))
+	assert.Equal(t, "error", attrValue(points[0], "result"))
+}
+
+func TestErrorType(t *testing.T) {
+	assert.Equal(t, "NotFound", errorType(apierrors.NewNotFound(schema.GroupResource{Resource: "scanjobs"}, "x")))
+	assert.Equal(t, "canceled", errorType(context.Canceled))
+	assert.Equal(t, "deadline_exceeded", errorType(context.DeadlineExceeded))
+	assert.Equal(t, "unknown", errorType(assert.AnError))
+}
+
+// collectDataPoints returns the int64 or float64 data points of the named metric as attribute sets.
+func collectDataPoints(t *testing.T, reader *sdkmetric.ManualReader, name string) []attributePoint {
+	t.Helper()
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &resourceMetrics))
+
+	var points []attributePoint
+	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+		for _, m := range scopeMetrics.Metrics {
+			if m.Name != name {
+				continue
+			}
+			switch data := m.Data.(type) {
+			case metricdata.Sum[int64]:
+				for _, point := range data.DataPoints {
+					points = append(points, attributePoint{attributes: point.Attributes, value: point.Value})
+				}
+			case metricdata.Histogram[float64]:
+				for _, point := range data.DataPoints {
+					points = append(points, attributePoint{attributes: point.Attributes, value: int64(point.Count)})
+				}
+			default:
+				t.Fatalf("unexpected data type %T for metric %s", m.Data, name)
+			}
+		}
+	}
+	return points
+}
+
+// attributePoint is a metric data point reduced to its attributes and value for assertions.
+type attributePoint struct {
+	attributes attribute.Set
+	value      int64
+}
+
+// attrValue returns the string form of the point attribute with the given key, or "" when absent.
+func attrValue[T interface{ attribute.Set | attributePoint }](holder T, key string) string {
+	var set attribute.Set
+	switch v := any(holder).(type) {
+	case attribute.Set:
+		set = v
+	case attributePoint:
+		set = v.attributes
+	}
+	value, ok := set.Value(attribute.Key(key))
+	if !ok {
+		return ""
+	}
+	return value.String()
+}

--- a/internal/handlers/node_scan_sbom.go
+++ b/internal/handlers/node_scan_sbom.go
@@ -32,18 +32,20 @@ func NewNodeScanSBOMHandler(
 	workDir string,
 	trivyDBRepository string,
 	trivyJavaDBRepository string,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
-) *NodeScanSBOMHandler {
-	return &NodeScanSBOMHandler{
+) *InstrumentedHandler {
+	return instrumentHandler(instrumentation, "NodeScanSBOMHandler", "node_scan_sbom", &NodeScanSBOMHandler{
 		scanSBOMBase: scanSBOMBase{
 			k8sClient:             k8sClient,
 			scheme:                scheme,
 			workDir:               workDir,
 			trivyDBRepository:     trivyDBRepository,
 			trivyJavaDBRepository: trivyJavaDBRepository,
+			instrumentation:       instrumentation,
 			logger:                logger.With("handler", "scan_node_sbom_handler"),
 		},
-	}
+	})
 }
 
 //nolint:funlen,gocognit // This function is responsible for orchestrating multiple steps in the node SBOM scanning process, making it inherently complex and lengthy.
@@ -71,6 +73,7 @@ func (h *NodeScanSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 	}, scanJob); err != nil {
 		if apierrors.IsNotFound(err) {
 			h.logger.ErrorContext(ctx, "NodeScanJob not found, stopping SBOM scan", "scanJob", nodeScanJobName, "namespace", nodeScanJobNamespace)
+			recordSpanSkipReason(ctx, skipReasonJobNotFound)
 			return nil
 		}
 
@@ -80,11 +83,13 @@ func (h *NodeScanSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 	if string(scanJob.GetUID()) != nodeScanJobUID {
 		h.logger.InfoContext(ctx, "NodeScanJob not found, stopping SBOM generation (UID changed)", "scanjob", nodeScanJobName, "namespace", nodeScanJobNamespace,
 			"uid", nodeScanJobUID)
+		recordSpanSkipReason(ctx, skipReasonUIDMismatch)
 		return nil
 	}
 
 	if scanJob.IsFailed() {
 		h.logger.InfoContext(ctx, "NodeScanJob is in failed state, stopping SBOM scan", "scanjob", nodeScanJobName, "namespace", nodeScanJobNamespace)
+		recordSpanSkipReason(ctx, skipReasonJobFailed)
 		return nil
 	}
 
@@ -103,6 +108,7 @@ func (h *NodeScanSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 		// The NodeScanJob may have been deleted while we were processing; abandon the update.
 		if apierrors.IsNotFound(err) {
 			h.logger.InfoContext(ctx, "NodeScanJob not found, stopping SBOM scan", "scanjob", nodeScanJobName, "namespace", nodeScanJobNamespace)
+			recordSpanSkipReason(ctx, skipReasonJobNotFound)
 			return nil
 		}
 		return fmt.Errorf("failed to update NodeScanJob status to SBOM generation in progress: %w", err)
@@ -115,6 +121,7 @@ func (h *NodeScanSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 	}, sbom); err != nil {
 		if apierrors.IsNotFound(err) {
 			h.logger.ErrorContext(ctx, "SBOM not found, stopping SBOM scan", "sbom", nodeSBOMName, "namespace", nodeSBOMNamespace)
+			recordSpanSkipReason(ctx, skipReasonObjectNotFound)
 			return nil
 		}
 
@@ -179,6 +186,7 @@ func (h *NodeScanSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 		// The NodeScanJob may have been deleted while we were processing; abandon the update.
 		if apierrors.IsNotFound(err) {
 			h.logger.InfoContext(ctx, "NodeScanJob not found, skipping completion update", "scanjob", nodeScanJobName, "namespace", nodeScanJobNamespace)
+			recordSpanSkipReason(ctx, skipReasonJobNotFound)
 			return nil
 		}
 		return fmt.Errorf("failed to update NodeScanJob status: %w", err)

--- a/internal/handlers/node_scan_sbom_test.go
+++ b/internal/handlers/node_scan_sbom_test.go
@@ -64,7 +64,7 @@ func TestNodeScanSBOMHandler_Handle(t *testing.T) {
 		WithStatusSubresource(&v1alpha1.NodeScanJob{}).
 		Build()
 
-	handler := NewNodeScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
+	handler := NewNodeScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, newNoopInstrumentation(), slog.Default())
 
 	message, err := json.Marshal(&ScanNodeSBOMMessage{
 		NodeBaseMessage: NodeBaseMessage{
@@ -174,7 +174,7 @@ func TestNodeScanSBOMHandler_Handle_StopProcessing(t *testing.T) {
 				Build()
 
 			cacheDir := t.TempDir()
-			handler := NewNodeScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
+			handler := NewNodeScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, newNoopInstrumentation(), slog.Default())
 
 			message, err := json.Marshal(&ScanNodeSBOMMessage{
 				NodeBaseMessage: NodeBaseMessage{

--- a/internal/handlers/nodescanjob_failure.go
+++ b/internal/handlers/nodescanjob_failure.go
@@ -23,12 +23,13 @@ type NodeScanJobFailureHandler struct {
 // NewNodeScanJobFailureHandler creates a new instance of NodeScanJobFailureHandler.
 func NewNodeScanJobFailureHandler(
 	k8sClient client.Client,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
-) *NodeScanJobFailureHandler {
-	return &NodeScanJobFailureHandler{
+) *InstrumentedFailureHandler {
+	return instrumentFailureHandler(instrumentation, "NodeScanJobFailureHandler", &NodeScanJobFailureHandler{
 		k8sClient: k8sClient,
 		logger:    logger.With("handler", "nodescanjob_failure_handler"),
-	}
+	})
 }
 
 // HandleFailure processes message failures and updates the associated NodeScanJob status.

--- a/internal/handlers/nodescanjob_failure_test.go
+++ b/internal/handlers/nodescanjob_failure_test.go
@@ -37,7 +37,7 @@ func TestNodeScanJobFailureHandler_HandleFailure(t *testing.T) {
 		WithStatusSubresource(nodeScanJob).
 		Build()
 
-	handler := NewNodeScanJobFailureHandler(k8sClient, slog.Default())
+	handler := NewNodeScanJobFailureHandler(k8sClient, newNoopInstrumentation(), slog.Default())
 
 	message, err := json.Marshal(&GenerateNodeSBOMMessage{
 		NodeBaseMessage: NodeBaseMessage{
@@ -74,7 +74,7 @@ func TestNodeScanJobFailureHandler_HandleFailure_NodeScanJobNotFound(t *testing.
 		WithScheme(scheme).
 		Build()
 
-	handler := NewNodeScanJobFailureHandler(k8sClient, slog.Default())
+	handler := NewNodeScanJobFailureHandler(k8sClient, newNoopInstrumentation(), slog.Default())
 
 	message, err := json.Marshal(&GenerateNodeSBOMMessage{
 		NodeBaseMessage: NodeBaseMessage{

--- a/internal/handlers/scan_sbom.go
+++ b/internal/handlers/scan_sbom.go
@@ -31,18 +31,20 @@ func NewScanSBOMHandler(
 	workDir string,
 	trivyDBRepository string,
 	trivyJavaDBRepository string,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
-) *ScanSBOMHandler {
-	return &ScanSBOMHandler{
+) *InstrumentedHandler {
+	return instrumentHandler(instrumentation, "ScanSBOMHandler", "scan_sbom", &ScanSBOMHandler{
 		scanSBOMBase: scanSBOMBase{
 			k8sClient:             k8sClient,
 			scheme:                scheme,
 			workDir:               workDir,
 			trivyDBRepository:     trivyDBRepository,
 			trivyJavaDBRepository: trivyJavaDBRepository,
+			instrumentation:       instrumentation,
 			logger:                logger.With("handler", "scan_sbom_handler"),
 		},
-	}
+	})
 }
 
 //nolint:funlen
@@ -70,6 +72,7 @@ func (h *ScanSBOMHandler) Handle(ctx context.Context, message messaging.Message)
 	}, scanJob); err != nil {
 		if apierrors.IsNotFound(err) {
 			h.logger.ErrorContext(ctx, "ScanJob not found, stopping SBOM scan", "scanJob", scanJobName, "namespace", scanJobNamespace)
+			recordSpanSkipReason(ctx, skipReasonJobNotFound)
 			return nil
 		}
 
@@ -79,11 +82,13 @@ func (h *ScanSBOMHandler) Handle(ctx context.Context, message messaging.Message)
 	if string(scanJob.GetUID()) != scanJobUID {
 		h.logger.InfoContext(ctx, "ScanJob not found, stopping SBOM generation (UID changed)", "scanjob", scanJobName, "namespace", scanJobNamespace,
 			"uid", scanJobUID)
+		recordSpanSkipReason(ctx, skipReasonUIDMismatch)
 		return nil
 	}
 
 	if scanJob.IsFailed() {
 		h.logger.InfoContext(ctx, "ScanJob is in failed state, stopping SBOM scan", "scanjob", scanJobName, "namespace", scanJobNamespace)
+		recordSpanSkipReason(ctx, skipReasonJobFailed)
 		return nil
 	}
 
@@ -104,6 +109,7 @@ func (h *ScanSBOMHandler) Handle(ctx context.Context, message messaging.Message)
 	}, sbom); err != nil {
 		if apierrors.IsNotFound(err) {
 			h.logger.ErrorContext(ctx, "SBOM not found, stopping SBOM scan", "sbom", sbomName, "namespace", sbomNamespace)
+			recordSpanSkipReason(ctx, skipReasonObjectNotFound)
 			return nil
 		}
 
@@ -111,6 +117,7 @@ func (h *ScanSBOMHandler) Handle(ctx context.Context, message messaging.Message)
 	}
 
 	results, summary, err := h.runTrivyScan(ctx, sbom.SPDX.Raw, message)
+	h.instrumentation.recordImageScanned(ctx, sbom.GetImageMetadata().RegistryURI, err)
 	if err != nil {
 		return err
 	}

--- a/internal/handlers/scan_sbom_helpers.go
+++ b/internal/handlers/scan_sbom_helpers.go
@@ -37,6 +37,7 @@ type scanSBOMBase struct {
 	workDir               string
 	trivyDBRepository     string
 	trivyJavaDBRepository string
+	instrumentation       *Instrumentation
 	logger                *slog.Logger
 }
 
@@ -124,7 +125,10 @@ func (b *scanSBOMBase) runTrivyScan(ctx context.Context, rawSPDX []byte, message
 	trivyArgs = append(trivyArgs, sbomFile.Name())
 	app.SetArgs(trivyArgs)
 
-	if err = app.ExecuteContext(ctx); err != nil {
+	trivyCtx, trivyDone := b.instrumentation.startTrivy(ctx, trivyCommandSBOM)
+	err = app.ExecuteContext(trivyCtx)
+	trivyDone(err)
+	if err != nil {
 		return nil, storagev1alpha1.Summary{}, fmt.Errorf("failed to execute trivy: %w", err)
 	}
 

--- a/internal/handlers/scan_sbom_test.go
+++ b/internal/handlers/scan_sbom_test.go
@@ -182,7 +182,7 @@ func testScanSBOM(t *testing.T, cacheDir, platform, sourceSBOMJSON, expectedRepo
 	err = json.Unmarshal(reportData, expectedReport)
 	require.NoError(t, err, "failed to unmarshal expected report file %s", expectedReportJSON)
 
-	handler := NewScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
+	handler := NewScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, newNoopInstrumentation(), slog.Default())
 
 	message, err := json.Marshal(&ScanSBOMMessage{
 		BaseMessage: BaseMessage{
@@ -320,7 +320,7 @@ func TestScanSBOMHandler_Handle_StopProcessing(t *testing.T) {
 				Build()
 
 			cacheDir := t.TempDir()
-			handler := NewScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
+			handler := NewScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, newNoopInstrumentation(), slog.Default())
 
 			message, err := json.Marshal(&ScanSBOMMessage{
 				BaseMessage: BaseMessage{

--- a/internal/handlers/scanjob_failure.go
+++ b/internal/handlers/scanjob_failure.go
@@ -23,12 +23,13 @@ type ScanJobFailureHandler struct {
 // NewScanJobFailureHandler creates a new instance of ScanJobFailureHandler.
 func NewScanJobFailureHandler(
 	k8sClient client.Client,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
-) *ScanJobFailureHandler {
-	return &ScanJobFailureHandler{
+) *InstrumentedFailureHandler {
+	return instrumentFailureHandler(instrumentation, "ScanJobFailureHandler", &ScanJobFailureHandler{
 		k8sClient: k8sClient,
 		logger:    logger.With("handler", "scanjob_failure_handler"),
-	}
+	})
 }
 
 // HandleFailure processes message failures and updates the associated ScanJob status.

--- a/internal/handlers/scanjob_failure_test.go
+++ b/internal/handlers/scanjob_failure_test.go
@@ -38,7 +38,7 @@ func TestScanJobFailureHandler_HandleFailure(t *testing.T) {
 		WithStatusSubresource(scanJob).
 		Build()
 
-	handler := NewScanJobFailureHandler(k8sClient, slog.Default())
+	handler := NewScanJobFailureHandler(k8sClient, newNoopInstrumentation(), slog.Default())
 
 	message, err := json.Marshal(&GenerateSBOMMessage{
 		BaseMessage: BaseMessage{

--- a/internal/handlers/utils_test.go
+++ b/internal/handlers/utils_test.go
@@ -13,9 +13,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
+	"github.com/nats-io/nats.go"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/registry"
 	"github.com/testcontainers/testcontainers-go/wait"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -71,11 +74,16 @@ const (
 
 // testMessage is a simple implementation of a message used for testing purposes.
 type testMessage struct {
-	data []byte
+	data    []byte
+	headers nats.Header
 }
 
 func (m *testMessage) Data() []byte {
 	return m.data
+}
+
+func (m *testMessage) Headers() nats.Header {
+	return m.headers
 }
 
 func (m *testMessage) InProgress() error {
@@ -233,4 +241,14 @@ func withCertificateAndKeyFiles(certFile, keyFile string) []testcontainers.Conta
 			wait.ForLog("listening on").WithStartupTimeout(60 * time.Second),
 		),
 	}
+}
+
+// newNoopInstrumentation builds an Instrumentation on no-op providers,
+// for tests that exercise handlers without asserting on telemetry.
+func newNoopInstrumentation() *Instrumentation {
+	instrumentation, err := NewInstrumentation(tracenoop.NewTracerProvider().Tracer("test"), metricnoop.NewMeterProvider().Meter("test"))
+	if err != nil {
+		panic(err)
+	}
+	return instrumentation
 }

--- a/internal/messaging/handler.go
+++ b/internal/messaging/handler.go
@@ -1,12 +1,17 @@
 package messaging
 
-import "context"
+import (
+	"context"
+
+	"github.com/nats-io/nats.go"
+)
 
 // Message represents a message received by the handler.
-// It provides access to the message data and allows marking the message as in-progress
+// It provides access to the message data and headers, and allows marking the message as in-progress
 // to extend the acknowledgement timeout during long-running operations.
 type Message interface {
 	Data() []byte
+	Headers() nats.Header
 	InProgress() error
 }
 

--- a/internal/messaging/publisher.go
+++ b/internal/messaging/publisher.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
 )
 
 const (
@@ -69,6 +71,10 @@ func (p *NatsPublisher) Publish(ctx context.Context, subject string, messageID s
 			jetstream.MsgIDHeader: []string{messageID},
 		},
 	}
+	// The trace context from ctx rides along in the message headers (W3C traceparent),
+	// so consumers can join the publishing trace.
+	telemetry.InjectNATS(ctx, msg)
+
 	if _, err := p.js.PublishMsg(ctx, msg); err != nil {
 		return fmt.Errorf("failed to publish message: %w", err)
 	}

--- a/internal/messaging/publisher_test.go
+++ b/internal/messaging/publisher_test.go
@@ -9,11 +9,16 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 const testPublisherSubject = "sbomscanner.publisher.test"
 
 func TestPublisher_Publish(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
 	opts := natstest.DefaultTestOptions
 	opts.Port = -1 // Use a random port
 	opts.JetStream = true
@@ -27,8 +32,14 @@ func TestPublisher_Publish(t *testing.T) {
 	publisher, err := NewNatsPublisher(t.Context(), nc, slog.Default())
 	require.NoError(t, err)
 
+	// Publish within an active span, so the message must carry its traceparent.
+	tracerProvider := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tracerProvider.Shutdown(t.Context()) })
+	publishCtx, span := tracerProvider.Tracer("test").Start(t.Context(), "publish")
+	defer span.End()
+
 	message := []byte(`{"data":"test data"}`)
-	err = publisher.Publish(t.Context(), testPublisherSubject, "id", message)
+	err = publisher.Publish(publishCtx, testPublisherSubject, "id", message)
 	require.NoError(t, err)
 
 	// Send a duplicate message with the same ID to test idempotency
@@ -52,4 +63,6 @@ func TestPublisher_Publish(t *testing.T) {
 	receivedMessage := messages[0]
 	assert.Equal(t, testPublisherSubject, receivedMessage.Subject())
 	assert.Equal(t, message, receivedMessage.Data())
+	assert.Contains(t, receivedMessage.Headers().Get("traceparent"), span.SpanContext().TraceID().String(),
+		"the message must carry the traceparent of the publishing context")
 }

--- a/internal/messaging/subscriber_test.go
+++ b/internal/messaging/subscriber_test.go
@@ -17,11 +17,16 @@ import (
 const testSubscriberSubject = "sbomscanner.subscriber.test"
 
 type testMessage struct {
-	data []byte
+	data    []byte
+	headers nats.Header
 }
 
 func (m *testMessage) Data() []byte {
 	return m.data
+}
+
+func (m *testMessage) Headers() nats.Header {
+	return m.headers
 }
 
 func (m *testMessage) InProgress() error {

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -160,6 +160,25 @@ var downwardAPIEnv = []struct {
 	{"K8S_CONTAINER_NAME", semconv.K8SContainerNameKey},
 }
 
+// instanceID identifies this replica, so series from replicas of the same service stay apart
+// (Prometheus derives the instance label from service.instance.id).
+// It prefers the pod identity from the downward API and falls back to the hostname,
+// which on Kubernetes is the pod name.
+func instanceID() string {
+	namespace, name := os.Getenv("K8S_POD_NAMESPACE"), os.Getenv("K8S_POD_NAME")
+	if namespace != "" && name != "" {
+		return namespace + "/" + name
+	}
+	if name != "" {
+		return name
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return hostname
+}
+
 // buildResource merges SDK defaults
 // (which already include attributes from OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME)
 // with the service name and version supplied by the caller,
@@ -168,6 +187,7 @@ func buildResource(ctx context.Context, serviceName, serviceVersion string) (*re
 	attrs := []attribute.KeyValue{
 		semconv.ServiceName(serviceName),
 		semconv.ServiceVersion(serviceVersion),
+		semconv.ServiceInstanceID(instanceID()),
 	}
 	for _, e := range downwardAPIEnv {
 		if v := os.Getenv(e.env); v != "" {

--- a/internal/telemetry/otel_test.go
+++ b/internal/telemetry/otel_test.go
@@ -72,6 +72,27 @@ func TestHistogramAggregationSelector(t *testing.T) {
 		histogramAggregationSelector(sdkmetric.InstrumentKindGauge))
 }
 
+// TestBuildResource_InstanceID checks that service.instance.id identifies the replica,
+// from the downward-API pod identity when present, from the hostname otherwise.
+func TestBuildResource_InstanceID(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	t.Setenv("K8S_POD_NAMESPACE", "sbomscanner")
+	t.Setenv("K8S_POD_NAME", "worker-abc123")
+
+	res, err := buildResource(context.Background(), "svc", "v0")
+	require.NoError(t, err)
+	attrs := attributesAsMap(res.Attributes())
+	assert.Equal(t, "sbomscanner/worker-abc123", attrs[string(semconv.ServiceInstanceIDKey)])
+
+	t.Setenv("K8S_POD_NAMESPACE", "")
+	t.Setenv("K8S_POD_NAME", "")
+	res, err = buildResource(context.Background(), "svc", "v0")
+	require.NoError(t, err)
+	attrs = attributesAsMap(res.Attributes())
+	assert.NotEmpty(t, attrs[string(semconv.ServiceInstanceIDKey)], "hostname fallback")
+}
+
 // TestBuildResource_ServiceAttrs checks that service.name and service.version end up on the resource.
 func TestBuildResource_ServiceAttrs(t *testing.T) {
 	// Clear inherited env to keep the test deterministic.

--- a/tilt-settings.yaml.example
+++ b/tilt-settings.yaml.example
@@ -1,8 +1,9 @@
 registry: ghcr.io
 use_private_registry: false
-storage: 
+telemetry: true
+storage:
     image: <username>/sbomscanner/storage
-controller: 
+controller:
     image: <username>/sbomscanner/controller
-worker: 
+worker:
     image: <username>/sbomscanner/worker


### PR DESCRIPTION
## Description

This PR instruments the worker, continuing the work started with the controller in #1280. Fixes #1218.

Until now, the job trace stopped at the controller: once a message was published to NATS, we lost track of it. Now the trace ID travels inside the message headers, so when the worker picks up a message it continues the same trace. The result is that a single scan shows up in Jaeger as one tree: the reconcile, then the catalog creation, then the SBOM generation for each image, then the vulnerability scan, with the Trivy runs visible inside each step. When a handler skips a message (for example because the job was deleted in the meantime), the span says why.

The worker also exports metrics now: how long each stage of the pipeline takes, how many images were scanned, how many vulnerabilities were found by severity, plus timings for registry calls and Trivy runs, and a counter for handler errors. The example Grafana dashboard gained a Worker row showing all of this, and the Tilt settings example now enables the telemetry stack by default so it is easy to try locally.

RFC 0009 is updated to describe what actually shipped.

---
<img width="1297" height="173" alt="image" src="https://github.com/user-attachments/assets/2c83dcaa-a6f0-475c-b836-1e43db6f600f" />

---

<img width="1741" height="1029" alt="image" src="https://github.com/user-attachments/assets/49b64dd6-3cf4-456b-a05d-c6d02553b518" />

---

<img width="1524" height="955" alt="image" src="https://github.com/user-attachments/assets/a2131049-7e2e-412f-9133-00f07b24759a" />

