### PR TITLE
feat(storage): add traces and  metrics

### DIFF
--- a/charts/sbomscanner/templates/storage/deployment.yaml
+++ b/charts/sbomscanner/templates/storage/deployment.yaml
@@ -48,6 +48,19 @@ spec:
           image: '{{ template "system_default_registry" . }}{{ .Values.storage.image.repository }}:{{ .Values.storage.image.tag }}'
           securityContext:
             {{ include "sbomscanner.securityContext" . | nindent 12 }}
+          {{- if .Values.observability.otel.endpoint }}
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.observability.otel.endpoint | quote }}
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          {{- end }}
           args:
             - -nats-url
             - {{ .Release.Name }}-nats.{{ .Release.Namespace }}.svc.cluster.local:4222

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/component-base/tracing"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -128,7 +129,7 @@ func run(cfg Config) error {
 	// The Prometheus bridge exports the controller-runtime metrics
 	// (controller_runtime_*, workqueue_*, rest_client_*, ...) over OTLP alongside our own;
 	// the controller-runtime metrics server keeps serving them for users on legacy Prometheus pull.
-	shutdownTelemetry, err := telemetry.Setup(signalHandler, "sbomscanner-controller", version.Version,
+	shutdownTelemetry, kubernetesClientTracerProvider, err := telemetry.Setup(signalHandler, "sbomscanner-controller", version.Version,
 		telemetry.WithMetricProducer(prombridge.NewMetricProducer(prombridge.WithGatherer(ctrlmetrics.Registry))),
 	)
 	if err != nil {
@@ -241,7 +242,13 @@ func run(cfg Config) error {
 
 	cacheByObject := buildCacheByObject(cfg)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	// Wrap the client transport (upstream Kubernetes wrapper) so API calls made
+	// inside a trace carry the W3C trace context and produce client spans,
+	// joining them to the storage apiserver's server spans.
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.Wrap(tracing.WrapperFor(kubernetesClientTracerProvider))
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		PprofBindAddress:       cfg.PprofAddr,

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -81,7 +81,7 @@ func run(cfg config) error {
 	}()
 
 	// Initialize OpenTelemetry. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
-	shutdownTelemetry, err := telemetry.Setup(ctx, "sbomscanner-mcp", version.Version)
+	shutdownTelemetry, _, err := telemetry.Setup(ctx, "sbomscanner-mcp", version.Version)
 	if err != nil {
 		return fmt.Errorf("initializing telemetry: %w", err)
 	}

--- a/cmd/storage/main.go
+++ b/cmd/storage/main.go
@@ -85,7 +85,7 @@ func run() error {
 	ctx := genericapiserver.SetupSignalContext()
 
 	// Initialize OpenTelemetry. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
-	shutdownTelemetry, err := telemetry.Setup(ctx, "sbomscanner-storage", version.Version)
+	shutdownTelemetry, _, err := telemetry.Setup(ctx, "sbomscanner-storage", version.Version)
 	if err != nil {
 		return fmt.Errorf("initializing telemetry: %w", err)
 	}

--- a/cmd/storage/main.go
+++ b/cmd/storage/main.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/docker/go-units"
+	"github.com/exaring/otelpgx"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go"
@@ -196,16 +197,43 @@ func newDB(ctx context.Context, pgURIFile, pgTLSCAFile string) (*pgxpool.Pool, e
 		return nil
 	}
 
+	// Trace SQL queries as child spans of the API request spans and record the
+	// semconv db.client.* operation metrics. Span names keep only the leading
+	// SQL keyword; full statements go on the span attributes.
+	// Pool-acquire spans are disabled as noise: acquire latency stays observable
+	// through the pgxpool.acquire_duration metric registered by RecordStats.
+	config.ConnConfig.Tracer = otelpgx.NewTracer(
+		otelpgx.WithTrimSQLInSpanName(),
+		otelpgx.WithDisableAcquireTracer(),
+	)
+
 	db, err := pgxpool.NewWithConfig(ctx, config)
 	if err != nil {
 		return nil, fmt.Errorf("creating connection pool: %w", err)
+	}
+
+	if err := otelpgx.RecordStats(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("recording database pool metrics: %w", err)
 	}
 
 	return db, nil
 }
 
 func runServer(ctx context.Context, db *pgxpool.Pool, nc *nats.Conn, logger *slog.Logger, cfg apiserver.StorageAPIServerConfig) error {
-	srv, err := apiserver.NewStorageAPIServer(db, nc, logger, cfg)
+	instrumentation, err := apiserver.NewInstrumentation(telemetry.Meter("internal/apiserver"))
+	if err != nil {
+		return fmt.Errorf("creating apiserver instrumentation: %w", err)
+	}
+	storeInstrumentation, err := storage.NewInstrumentation(
+		telemetry.Tracer("internal/storage"),
+		telemetry.Meter("internal/storage"),
+	)
+	if err != nil {
+		return fmt.Errorf("creating storage instrumentation: %w", err)
+	}
+
+	srv, err := apiserver.NewStorageAPIServer(db, nc, instrumentation, storeInstrumentation, logger, cfg)
 	if err != nil {
 		return fmt.Errorf("creating storage API server: %w", err)
 	}

--- a/cmd/storage/main.go
+++ b/cmd/storage/main.go
@@ -19,6 +19,9 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	prombridge "go.opentelemetry.io/contrib/bridges/prometheus"
 
 	"github.com/kubewarden/sbomscanner/internal/apiserver"
 	"github.com/kubewarden/sbomscanner/internal/cmdutil"
@@ -86,7 +89,16 @@ func run() error {
 	ctx := genericapiserver.SetupSignalContext()
 
 	// Initialize OpenTelemetry. No-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
-	shutdownTelemetry, _, err := telemetry.Setup(ctx, "sbomscanner-storage", version.Version)
+	// The Prometheus bridge exports the process and Go runtime metrics
+	// (process_*, go_*) over OTLP alongside our own.
+	runtimeRegistry := prometheus.NewRegistry()
+	runtimeRegistry.MustRegister(
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
+	)
+	shutdownTelemetry, _, err := telemetry.Setup(ctx, "sbomscanner-storage", version.Version,
+		telemetry.WithMetricProducer(prombridge.NewMetricProducer(prombridge.WithGatherer(runtimeRegistry))),
+	)
 	if err != nil {
 		return fmt.Errorf("initializing telemetry: %w", err)
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	prombridge "go.opentelemetry.io/contrib/bridges/prometheus"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/component-base/tracing"
 )
 
 const (
@@ -110,7 +111,7 @@ func run(cfg config) error {
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		collectors.NewGoCollector(),
 	)
-	shutdownTelemetry, err := telemetry.Setup(ctx, "sbomscanner-worker", version.Version,
+	shutdownTelemetry, kubernetesClientTracerProvider, err := telemetry.Setup(ctx, "sbomscanner-worker", version.Version,
 		telemetry.WithMetricProducer(prombridge.NewMetricProducer(prombridge.WithGatherer(runtimeRegistry))),
 	)
 	if err != nil {
@@ -124,7 +125,11 @@ func run(cfg config) error {
 		}
 	}()
 
+	// Wrap the client transport (upstream Kubernetes wrapper) so API calls made
+	// inside a trace carry the W3C trace context and produce client spans,
+	// joining them to the storage apiserver's server spans.
 	config := ctrl.GetConfigOrDie()
+	config.Wrap(tracing.WrapperFor(kubernetesClientTracerProvider))
 	natsOpts := []nats.Option{
 		nats.RootCAs(cfg.NatsCAFile),
 		nats.ClientCert(cfg.NatsCertFile, cfg.NatsKeyFile),

--- a/docs/rfc/0009_opentelemetry_instrumentation.md
+++ b/docs/rfc/0009_opentelemetry_instrumentation.md
@@ -103,6 +103,18 @@ so the instrumentation cannot retrigger the reconcile loops it observes.
 On the message hop, the trace context travels in the NATS headers instead:
 publishers inject the current traceparent and worker consumer spans parent from it.
 
+On the Kubernetes API hop, the trace context travels as the standard HTTP `traceparent` header:
+the controller and the worker instrument their clients with the
+[upstream Kubernetes client wrapper](https://pkg.go.dev/k8s.io/component-base/tracing#WrapperFor),
+the kube-apiserver aggregation proxy forwards the header,
+and the storage API server's spans join the caller's trace down to the SQL statements.
+The client spans are sampled parent-based:
+an API call made inside a trace produces a child span,
+while background traffic (leader election renewals, informer resyncs) produces nothing,
+instead of flooding the backend with one-span traces.
+One carrier per transport: the annotation for the resource hop,
+NATS headers for the message hop, HTTP headers for the API-call hop.
+
 ## Metric label cardinality
 
 Every metric label value must come from a fixed, low-cardinality set known at design time.
@@ -118,11 +130,11 @@ and Grafana Labs on [managing high-cardinality metrics](https://grafana.com/blog
 The following attribute classes are banned from metric labels:
 
 - Pod identifiers (`k8s.pod.name`, `k8s.pod.uid`) and anything else with a generated suffix. Every rollout or scale event mints new ones, so cardinality grows monotonically.
-- Full image references with digest or tag. The label uses `repository`; the full reference goes on the span, the log record, or an [exemplar](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exemplars).
+- Full image references with digest or tag. The label uses `repository`; the full reference goes on the span or the log record.
 - Raw error strings. The label uses a finite `error.type` enum.
 - Free-form input: session IDs, SQL statements, request paths with IDs, user IDs, IP addresses.
 
-High-cardinality data belongs on spans, on log fields, or as exemplars.
+High-cardinality data belongs on spans or on log fields.
 
 Per-workload metrics (`worker.workload.*`) keep the owning controller's `kind`, `namespace`, and `name` on the label set.
 Cardinality grows with the number of scanned workloads in the cluster, not over time: workload names are operator-set and only change on intentional rename.
@@ -140,6 +152,22 @@ The default is applied in the shared telemetry setup only when the standard
 so the variable keeps its standard behaviour:
 setting it to `explicit_bucket_histogram` restores classic histograms
 for pipelines without exponential-histogram support.
+
+## Exemplars
+
+Histograms recorded inside a sampled span automatically carry
+[exemplars](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exemplars):
+occasional concrete measurements stamped with the trace and span identifiers.
+This is the default SDK behaviour
+([trace-based exemplar filter](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#exemplar-defaults)),
+applies to every histogram in the catalogue below, and requires no per-metric code.
+Backends that store exemplars
+(e.g. Prometheus with [exemplar storage](https://prometheus.io/docs/prometheus/latest/feature_flags/#exemplars-storage))
+keep them alongside the aggregated data,
+and Grafana renders them as dots on latency panels that link straight to the trace,
+turning "this percentile spiked" into "here is the exact slow request".
+Exemplars carry only the trace identity;
+high-cardinality request details stay on the linked span.
 
 ## Traces and metrics catalogue
 
@@ -171,13 +199,13 @@ backed by the bounded `scanjob.trigger` / `nodescanjob.trigger` attribute.
 
 Metrics:
 
-| Metric                           | Type    | Labels (bounded)                                                   | Exemplars                 |
-| :------------------------------- | :------ | :------------------------------------------------------------------ | :------------------------ |
-| `controller.webhook.decisions`   | Counter | `type` (`validating` / `mutating`), `kind`, `operation`, `allowed`, `reason` | `trace_id`, `request.uid` |
-| `controller.registry_scan.ticks` | Counter | `result`                                                             | `trace_id`                |
-| `controller.node_scan.ticks`     | Counter | `result`                                                             | `trace_id`                |
-| `sbomscanner.scanjobs`           | Counter | `result` (`complete` / `failed`), `source` (`registry` / `workload`) | `trace_id`                |
-| `sbomscanner.nodescanjobs`       | Counter | `result` (`complete` / `failed`)                                     | `trace_id`                |
+| Metric                           | Type    | Labels (bounded)                                                   |
+| :------------------------------- | :------ | :------------------------------------------------------------------ |
+| `controller.webhook.decisions`   | Counter | `type` (`validating` / `mutating`), `kind`, `operation`, `allowed`, `reason` |
+| `controller.registry_scan.ticks` | Counter | `result`                                                             |
+| `controller.node_scan.ticks`     | Counter | `result`                                                             |
+| `sbomscanner.scanjobs`           | Counter | `result` (`complete` / `failed`), `source` (`registry` / `workload`) |
+| `sbomscanner.nodescanjobs`       | Counter | `result` (`complete` / `failed`)                                     |
 
 Reconcile durations and error counts are deliberately not duplicated here:
 controller-runtime already exports them, along with the workqueue, rest-client, webhook-server,
@@ -208,34 +236,54 @@ reconcile → catalog → per-image SBOM generation → scan.
 
 Metrics:
 
-| Metric                          | Type      | Labels (bounded)                                                                                  | Exemplars                   |
-| :------------------------------- | :-------- | :-------------------------------------------------------------------------------------------------- | :--------------------------- |
-| `worker.scan.duration`          | Histogram | `stage` (`catalog` / `generate_sbom` / `scan_sbom` / `generate_node_sbom` / `node_scan_sbom`), `result` | `trace_id`                  |
-| `sbomscanner.images.scanned`    | Counter   | `registry` (host), `result`                                                                          | `trace_id`                  |
-| `worker.registry.call.duration` | Histogram | `operation` (`catalog` / `list_repository_contents` / `get_descriptor` / `get_image_details`), `result` | `trace_id`                  |
-| `worker.trivy.duration`         | Histogram | `command` (`image` / `sbom` / `filesystem`), `result`                                                | `trace_id`                  |
-| `worker.handler.errors`         | Counter   | `handler`, `error.type` (Kubernetes status reason, `canceled`, `deadline_exceeded`, or `unknown`)    | `trace_id`                  |
+| Metric                          | Type      | Labels (bounded)                                                                                  |
+| :------------------------------- | :-------- | :-------------------------------------------------------------------------------------------------- |
+| `worker.scan.duration`          | Histogram | `stage` (`catalog` / `generate_sbom` / `scan_sbom` / `generate_node_sbom` / `node_scan_sbom`), `result` |
+| `sbomscanner.images.scanned`    | Counter   | `registry` (host), `result`                                                                          |
+| `worker.registry.call.duration` | Histogram | `operation` (`catalog` / `list_repository_contents` / `get_descriptor` / `get_image_details`), `result` |
+| `worker.trivy.duration`         | Histogram | `command` (`image` / `sbom` / `filesystem`), `result`                                                |
+| `worker.handler.errors`         | Counter   | `handler`, `error.type` (Kubernetes status reason, `canceled`, `deadline_exceeded`, or `unknown`)    |
 
 ### Storage
 
 Traces:
 
-| Span                    | Triggered by                                                                            | Key attributes                                                                                     |
-| :---------------------- | :-------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------- |
-| `APIServer request`     | `otelhttp.NewHandler` on the aggregated `genericapiserver` chain                        | `http.method`, `http.route`, `http.status_code`, `k8s.api.verb`, `k8s.api.resource`                |
-| `Storage <Kind>.<Verb>` | REST storage methods on `Image` / `SBOM` / `VulnerabilityReport` / `WorkloadScanReport` | `k8s.api.verb`, `k8s.api.resource`, `k8s.namespace.name`, `k8s.object.name`, `result`              |
-| `Postgres <op>`         | `otelpgx.NewTracer()` on `pgxpool.Config.ConnConfig.Tracer`                             | `db.system=postgresql`, `db.operation`, `db.sql.table`, `db.rows_affected`                         |
-| `Watch fan-out publish` | `internal/storage/watcher.go` publishing to NATS                                        | `messaging.system=nats`, `messaging.destination.name`, `event.type` (`added`/`modified`/`deleted`) |
-| `Watch fan-out consume` | Storage-side NATS subscriber                                                            | `messaging.system=nats`, `messaging.consumer.name`, `event.type`                                   |
+| Span                                                       | Triggered by                                                                                                    | Key attributes                                                                                                   |
+| :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
+| `GET` / `POST` / ... (HTTP method)                         | [otelhttp](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp) server handler, outermost on the aggregated API server handler chain | standard [HTTP server semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/)          |
+| `<Kind>Store.<Operation>`                                  | Each storage operation (`Create`, `Get`, `GetList`, `GuaranteedUpdate`, `Delete`, `Watch`) on the served resources | `k8s.namespace.name`, `k8s.object.name`, `storage.result` (`success` / `not_found` / `already_exists` / `error`)   |
+| `query <KEYWORD>` (e.g. `query INSERT`)                    | [otelpgx](https://github.com/exaring/otelpgx) tracer on the pgx pool                                               | standard [database client semantic conventions](https://opentelemetry.io/docs/specs/semconv/database/database-spans/), full SQL statement |
+| `NatsBroadcaster.Publish`                                  | Watch fan-out publish leg: each write publishes its event to NATS with the write's trace context in the headers    | `messaging.system=nats`, `messaging.destination.name`, `event.type` (`added` / `modified` / `deleted`)             |
+| `NatsWatcher.HandleMessage`                                | Watch fan-out consume leg on every storage replica, parented from the publishing write                             | `messaging.system=nats`, `messaging.destination.name`, `event.type`                                                |
+| `WorkloadScanReportWatcher.HandleVulnerabilityReportEvent` | VulnerabilityReport events fanned out as synthetic WorkloadScanReport events                                       | `messaging.system=nats`, `messaging.destination.name`                                                              |
+
+The HTTP server span is extracted before any other filter runs, so it covers the whole request, authentication included.
+Machinery requests (probes, discovery, OpenAPI aggregation) produce no server spans:
+they are polled every few seconds without a trace context,
+and each request would otherwise become a one-span root trace.
+Direct client requests remain traced.
+Not found and already exists are recorded as expected outcomes on the `storage.result` attribute, not as span errors:
+a miss on a lookup is normal control flow and must not light up traces as failures.
+Pool-acquire spans are disabled as noise; acquire latency stays observable through the pool metrics below.
 
 Metrics:
 
-| Metric                               | Type      | Labels (bounded)                         | Exemplars                       |
-| :----------------------------------- | :-------- | :--------------------------------------- | :------------------------------ |
-| `storage.apiserver.request.duration` | Histogram | `verb`, `resource`, `code`               | `trace_id`, `namespace`, `name` |
-| `storage.postgres.query.duration`    | Histogram | `db.operation`, `db.sql.table`, `result` | `trace_id`                      |
-| `storage.watch.events`               | Counter   | `resource`, `event.type`                 | `trace_id`, `namespace`, `name` |
-| `storage.watch.subscribers`          | Gauge     | `resource`                               | `trace_id`                      |
+| Metric                               | Type      | Labels (bounded)           |
+| :----------------------------------- | :-------- | :------------------------- |
+| `storage.apiserver.request.duration` | Histogram | `verb`, `resource`, `code` |
+| `storage.watch.events`               | Counter   | `resource`, `event.type`   |
+
+The request duration histogram covers resource requests only:
+non-resource endpoints (health, discovery, OpenAPI) are skipped,
+and so are long-running requests (watches), whose duration is a connection lifetime, not a latency.
+
+The instrumentation libraries add the standard families on top:
+otelhttp exports [`http.server.request.duration`](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/),
+and otelpgx exports [`db.client.operation.duration`](https://opentelemetry.io/docs/specs/semconv/database/database-metrics/)
+(labeled by the pgx operation type) together with the connection pool gauges.
+A separate first-party Postgres histogram would duplicate that signal while requiring SQL parsing to label it,
+so the semantic-convention metric is the source of truth for query latency;
+per-statement detail lives on the spans.
 
 ### MCP
 
@@ -248,11 +296,11 @@ Traces:
 
 Metrics:
 
-| Metric                      | Type      | Labels (bounded)      | Exemplars                |
-| :-------------------------- | :-------- | :-------------------- | :----------------------- |
-| `mcp.tool.calls`            | Counter   | `tool.name`, `result` | `trace_id`, `session.id` |
-| `mcp.tool.call.duration`    | Histogram | `tool.name`, `result` | `trace_id`, `session.id` |
-| `mcp.rate_limit.rejections` | Counter   | `tool.name`           | `trace_id`, `session.id` |
+| Metric                      | Type      | Labels (bounded)      |
+| :-------------------------- | :-------- | :-------------------- |
+| `mcp.tool.calls`            | Counter   | `tool.name`, `result` |
+| `mcp.tool.call.duration`    | Histogram | `tool.name`, `result` |
+| `mcp.rate_limit.rejections` | Counter   | `tool.name`           |
 
 # Drawbacks
 

--- a/examples/dashboards/sbomscanner.json
+++ b/examples/dashboards/sbomscanner.json
@@ -797,7 +797,8 @@
         {
           "refId": "A",
           "expr": "histogram_quantile(0.95, sum by (controller) (rate(controller_runtime_reconcile_time_seconds[$__rate_interval])))",
-          "legendFormat": "{{controller}}"
+          "legendFormat": "{{controller}}",
+          "exemplar": true
         }
       ],
       "interval": "2m"
@@ -955,7 +956,8 @@
         {
           "refId": "A",
           "expr": "histogram_quantile(0.95, sum by (name) (rate(workqueue_queue_duration_seconds[$__rate_interval])))",
-          "legendFormat": "{{name}}"
+          "legendFormat": "{{name}}",
+          "exemplar": true
         }
       ],
       "interval": "2m"
@@ -1628,7 +1630,8 @@
         {
           "refId": "A",
           "expr": "histogram_quantile(0.95, sum by (stage) (rate(worker_scan_duration_seconds[$__rate_interval])))",
-          "legendFormat": "{{stage}}"
+          "legendFormat": "{{stage}}",
+          "exemplar": true
         }
       ],
       "interval": "2m"
@@ -1723,7 +1726,8 @@
         {
           "refId": "A",
           "expr": "histogram_quantile(0.95, sum by (operation) (rate(worker_registry_call_duration_seconds[$__rate_interval])))",
-          "legendFormat": "{{operation}}"
+          "legendFormat": "{{operation}}",
+          "exemplar": true
         }
       ],
       "interval": "2m"
@@ -1770,7 +1774,8 @@
         {
           "refId": "A",
           "expr": "sum by (registry) (rate(sbomscanner_images_scanned_total[$__rate_interval]))",
-          "legendFormat": "{{registry}}"
+          "legendFormat": "{{registry}}",
+          "exemplar": true
         }
       ],
       "interval": "2m"
@@ -1912,6 +1917,309 @@
         {
           "refId": "A",
           "expr": "rate(process_cpu_seconds_total{job=\"sbomscanner-worker\"}[$__rate_interval])",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 400,
+      "type": "row",
+      "title": "Storage",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 79
+      },
+      "panels": []
+    },
+    {
+      "id": 401,
+      "type": "timeseries",
+      "title": "Request duration p95 by verb and resource",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 80
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (verb, resource) (rate(storage_apiserver_request_duration_seconds[$__rate_interval])))",
+          "legendFormat": "{{verb}} {{resource}}",
+          "exemplar": true
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 402,
+      "type": "timeseries",
+      "title": "Requests by code",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 80
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (code) (histogram_count(rate(storage_apiserver_request_duration_seconds[$__rate_interval])))",
+          "legendFormat": "{{code}}"
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 403,
+      "type": "timeseries",
+      "title": "Postgres operation p95",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 80
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (pgx_operation_type) (rate(db_client_operation_duration_seconds{job=\"sbomscanner-storage\"}[$__rate_interval])))",
+          "legendFormat": "{{pgx_operation_type}}",
+          "exemplar": true
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 404,
+      "type": "timeseries",
+      "title": "Watch events by resource and type",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 88
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (resource, event_type) (rate(storage_watch_events_total[$__rate_interval]))",
+          "legendFormat": "{{resource}} {{event_type}}"
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 405,
+      "type": "timeseries",
+      "title": "Memory (RSS)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 88
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "process_resident_memory_bytes{job=\"sbomscanner-storage\"}",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "interval": "2m"
+    },
+    {
+      "id": 406,
+      "type": "timeseries",
+      "title": "CPU",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 88
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "noValue": "0",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "pointSize": 5
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(process_cpu_seconds_total{job=\"sbomscanner-storage\"}[$__rate_interval])",
           "legendFormat": "{{instance}}"
         }
       ],

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,8 @@ require (
 
 require go.opentelemetry.io/contrib/bridges/prometheus v0.69.0
 
+require github.com/exaring/otelpgx v0.11.1
+
 require (
 	cel.dev/expr v0.25.2 // indirect
 	cloud.google.com/go v0.123.0 // indirect
@@ -421,7 +423,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,8 @@ github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb
 github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
+github.com/exaring/otelpgx v0.11.1 h1:pE79fIg/qh/Lpu00kvswFC5dKfqyJJhMJ4Y4N3w5Lj4=
+github.com/exaring/otelpgx v0.11.1/go.mod h1:3OojrUKhhy3lTbYIMBijP3YjMey/jo14eHAW5cXcUdk=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/extism/go-sdk v1.7.1 h1:lWJos6uY+tRFdlIHR+SJjwFDApY7OypS/2nMhiVQ9Sw=

--- a/hack/telemetry.yaml
+++ b/hack/telemetry.yaml
@@ -196,8 +196,18 @@ data:
           # can end up holding a single sample and return nothing.
           timeInterval: 60s
           exemplarTraceIdDestinations:
+            # Internal Explore link, broken since the Jaeger datasource backend
+            # migration (default on since Grafana 12.0, frontend removed in 12.2):
+            # the exemplar link's queryType is not understood by the backend, and
+            # the trace id trim from grafana/grafana#95786 (grafana/grafana#95784)
+            # was lost. Issue to be filed upstream; restore this once fixed.
+            # - name: trace_id
+            #   datasourceUid: jaeger
             - name: trace_id
-              datasourceUid: jaeger
+              # $$ escapes Grafana's provisioning-time env var expansion;
+              # the datasource must receive the literal ${__value.raw}.
+              url: http://localhost:16686/trace/$${__value.raw}
+              urlDisplayLabel: View in Jaeger
       - name: Jaeger
         uid: jaeger
         type: jaeger

--- a/internal/apiserver/instrumentation.go
+++ b/internal/apiserver/instrumentation.go
@@ -1,0 +1,107 @@
+package apiserver
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"k8s.io/apimachinery/pkg/util/sets"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/endpoints/responsewriter"
+
+	"github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
+)
+
+// Instrumentation bundles the metric instruments shared by the storage API server.
+// Disabled telemetry is represented by no-op providers.
+type Instrumentation struct {
+	requestDuration metric.Float64Histogram
+}
+
+// NewInstrumentation creates a new Instrumentation.
+func NewInstrumentation(meter metric.Meter) (*Instrumentation, error) {
+	requestDuration, err := meter.Float64Histogram(
+		"storage.apiserver.request.duration",
+		metric.WithDescription("Duration of resource requests served by the storage API server."),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating storage.apiserver.request.duration histogram: %w", err)
+	}
+
+	return &Instrumentation{
+		requestDuration: requestDuration,
+	}, nil
+}
+
+// requestDurationFilter records the request duration histogram (verb, resource, code),
+// skipping non-resource and long-running requests.
+// Resources outside servedResources are recorded as "unknown": the resource label
+// is parsed from the request path, and arbitrary values would grow the series count.
+func (i *Instrumentation) requestDurationFilter(
+	handler http.Handler,
+	longRunning apirequest.LongRunningRequestCheck,
+	servedResources sets.Set[string],
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestInfo, ok := apirequest.RequestInfoFrom(req.Context())
+		if !ok || !requestInfo.IsResourceRequest || (longRunning != nil && longRunning(req, requestInfo)) {
+			handler.ServeHTTP(w, req)
+			return
+		}
+
+		resource := requestInfo.Resource
+		if !servedResources.Has(resource) {
+			resource = "unknown"
+		}
+
+		recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+		handler.ServeHTTP(responsewriter.WrapForHTTP1Or2(recorder), req)
+
+		i.requestDuration.Record(req.Context(), time.Since(start).Seconds(), metric.WithAttributes(
+			attribute.String("verb", requestInfo.Verb),
+			attribute.String("resource", resource),
+			attribute.Int("code", recorder.status),
+		))
+	})
+}
+
+// isMachineryRequest reports whether the request is API machinery polling
+// (health probes, OpenAPI aggregation, discovery) rather than a resource request.
+func isMachineryRequest(req *http.Request) bool {
+	path := req.URL.Path
+	for _, root := range []string{"/healthz", "/readyz", "/livez", "/openapi"} {
+		if path == root || strings.HasPrefix(path, root+"/") {
+			return true
+		}
+	}
+
+	switch path {
+	case "/apis",
+		"/apis/" + v1alpha1.GroupName,
+		fmt.Sprintf("/apis/%s/%s", v1alpha1.GroupName, v1alpha1.SchemeGroupVersion.Version):
+		return true
+	}
+	return false
+}
+
+// statusRecorder captures the response status code.
+type statusRecorder struct {
+	http.ResponseWriter
+
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+// Unwrap returns the original ResponseWriter, as required by responsewriter.UserProvidedDecorator.
+func (r *statusRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
+}

--- a/internal/apiserver/instrumentation_test.go
+++ b/internal/apiserver/instrumentation_test.go
@@ -1,0 +1,145 @@
+package apiserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"k8s.io/apimachinery/pkg/util/sets"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+var testServedResources = sets.New("images")
+
+func newTestInstrumentation(t *testing.T) (*Instrumentation, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() {
+		require.NoError(t, meterProvider.Shutdown(context.Background()))
+	})
+
+	instrumentation, err := NewInstrumentation(meterProvider.Meter("test"))
+	require.NoError(t, err)
+	return instrumentation, reader
+}
+
+func requestDurationDataPoints(t *testing.T, reader *sdkmetric.ManualReader) []metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &resourceMetrics))
+
+	for _, scope := range resourceMetrics.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != "storage.apiserver.request.duration" {
+				continue
+			}
+			histogram, ok := m.Data.(metricdata.Histogram[float64])
+			require.True(t, ok, "unexpected data type %T", m.Data)
+			return histogram.DataPoints
+		}
+	}
+	return nil
+}
+
+func resourceGetRequest(t *testing.T) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/storage.sbomscanner.kubewarden.io/v1alpha1/namespaces/default/images/my-image", nil)
+	return req.WithContext(apirequest.WithRequestInfo(req.Context(), &apirequest.RequestInfo{
+		IsResourceRequest: true,
+		Verb:              "get",
+		Resource:          "images",
+	}))
+}
+
+// TestRequestDurationFilter asserts one histogram point labeled with the verb,
+// the resource, and the response code.
+func TestRequestDurationFilter(t *testing.T) {
+	instrumentation, reader := newTestInstrumentation(t)
+
+	handler := instrumentation.requestDurationFilter(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}), nil, testServedResources)
+	handler.ServeHTTP(httptest.NewRecorder(), resourceGetRequest(t))
+
+	points := requestDurationDataPoints(t, reader)
+	require.Len(t, points, 1)
+	assert.Equal(t, uint64(1), points[0].Count)
+
+	verb, ok := points[0].Attributes.Value("verb")
+	require.True(t, ok)
+	assert.Equal(t, "get", verb.AsString())
+	resource, ok := points[0].Attributes.Value("resource")
+	require.True(t, ok)
+	assert.Equal(t, "images", resource.AsString())
+	code, ok := points[0].Attributes.Value("code")
+	require.True(t, ok)
+	assert.Equal(t, int64(http.StatusNotFound), code.AsInt64())
+}
+
+// TestRequestDurationFilter_SkipsNonResourceRequests asserts that requests
+// without resource semantics (healthz, openapi) are not recorded.
+func TestRequestDurationFilter_SkipsNonResourceRequests(t *testing.T) {
+	instrumentation, reader := newTestInstrumentation(t)
+
+	handler := instrumentation.requestDurationFilter(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), nil, testServedResources)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req = req.WithContext(apirequest.WithRequestInfo(req.Context(), &apirequest.RequestInfo{
+		IsResourceRequest: false,
+		Path:              "/healthz",
+	}))
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Empty(t, requestDurationDataPoints(t, reader))
+}
+
+// TestRequestDurationFilter_SkipsLongRunningRequests asserts that watch-style
+// requests are not recorded: their duration is a connection lifetime, not a latency.
+func TestRequestDurationFilter_SkipsLongRunningRequests(t *testing.T) {
+	instrumentation, reader := newTestInstrumentation(t)
+
+	longRunning := func(*http.Request, *apirequest.RequestInfo) bool { return true }
+	handler := instrumentation.requestDurationFilter(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), longRunning, testServedResources)
+	handler.ServeHTTP(httptest.NewRecorder(), resourceGetRequest(t))
+
+	assert.Empty(t, requestDurationDataPoints(t, reader))
+}
+
+// TestRequestDurationFilter_NormalizesUnknownResources asserts that resources
+// outside the served set are recorded as "unknown", so arbitrary request paths
+// cannot grow the resource label cardinality.
+func TestRequestDurationFilter_NormalizesUnknownResources(t *testing.T) {
+	instrumentation, reader := newTestInstrumentation(t)
+
+	handler := instrumentation.requestDurationFilter(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}), nil, testServedResources)
+
+	req := httptest.NewRequest(http.MethodGet, "/apis/storage.sbomscanner.kubewarden.io/v1alpha1/namespaces/default/bogus/my-name", nil)
+	req = req.WithContext(apirequest.WithRequestInfo(req.Context(), &apirequest.RequestInfo{
+		IsResourceRequest: true,
+		Verb:              "get",
+		Resource:          "bogus",
+	}))
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	points := requestDurationDataPoints(t, reader)
+	require.Len(t, points, 1)
+
+	resource, ok := points[0].Attributes.Value("resource")
+	require.True(t, ok)
+	assert.Equal(t, "unknown", resource.AsString())
+}

--- a/internal/apiserver/storage.go
+++ b/internal/apiserver/storage.go
@@ -4,18 +4,22 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"slices"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
 	mutatingadmissionpolicy "k8s.io/apiserver/pkg/admission/plugin/policy/mutating"
 	validatingadmissionpolicy "k8s.io/apiserver/pkg/admission/plugin/policy/validating"
 	"k8s.io/apiserver/pkg/endpoints/openapi"
+	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
@@ -74,7 +78,14 @@ type StorageAPIServer struct {
 	dynamicCertKeyPairContent *dynamiccertificates.DynamicCertKeyPairContent
 }
 
-func NewStorageAPIServer(db *pgxpool.Pool, nc *nats.Conn, logger *slog.Logger, cfg StorageAPIServerConfig) (*StorageAPIServer, error) { //nolint:funlen
+func NewStorageAPIServer(
+	db *pgxpool.Pool,
+	nc *nats.Conn,
+	instrumentation *Instrumentation,
+	storeInstrumentation *storage.Instrumentation,
+	logger *slog.Logger,
+	cfg StorageAPIServerConfig,
+) (*StorageAPIServer, error) {
 	// Setup dynamic certs
 	dynamicCertKeyPairContent, err := dynamiccertificates.NewDynamicServingContentFromFiles(
 		"storage-serving-certs",
@@ -138,6 +149,15 @@ func NewStorageAPIServer(db *pgxpool.Pool, nc *nats.Conn, logger *slog.Logger, c
 
 	serverConfig.RESTOptionsGetter = &RestOptionsGetter{}
 
+	// The stores are built before the handler chain: the duration filter needs
+	// the served resource names to bound the resource metric label.
+	v1alpha1storage, watchers, err := buildStores(serverConfig.RESTOptionsGetter, db, nc, storeInstrumentation, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	serverConfig.BuildHandlerChainFunc = buildHandlerChain(instrumentation, sets.KeySet(v1alpha1storage))
+
 	if err := recommendedOptions.ApplyTo(serverConfig); err != nil {
 		return nil, fmt.Errorf("error applying options to server config: %w", err)
 	}
@@ -154,69 +174,6 @@ func NewStorageAPIServer(db *pgxpool.Pool, nc *nats.Conn, logger *slog.Logger, c
 
 	// Create API group and storage
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(v1alpha1.GroupName, Scheme, metav1.ParameterCodec, Codecs)
-
-	imageStore, imageWatchers, err := storage.NewImageStore(Scheme, serverConfig.RESTOptionsGetter, db, nc, logger)
-	if err != nil {
-		return nil, fmt.Errorf("error creating Image store: %w", err)
-	}
-
-	sbomStore, sbomWatchers, err := storage.NewSBOMStore(Scheme, serverConfig.RESTOptionsGetter, db, nc, logger)
-	if err != nil {
-		return nil, fmt.Errorf("error creating SBOM store: %w", err)
-	}
-
-	vulnerabilityReportStore, vulnerabilityReportWatchers, err := storage.NewVulnerabilityReportStore(
-		Scheme,
-		serverConfig.RESTOptionsGetter,
-		db,
-		nc,
-		logger,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error creating VulnerabilityReport store: %w", err)
-	}
-
-	workloadScanReportStore, workloadScanReportWatchers, err := storage.NewWorkloadScanReportStore(
-		Scheme,
-		serverConfig.RESTOptionsGetter,
-		db,
-		nc,
-		logger,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error creating WorkloadScanReport store: %w", err)
-	}
-
-	nodeSBOMStore, nodeSBOMWatchers, err := storage.NewNodeSBOMStore(
-		Scheme,
-		serverConfig.RESTOptionsGetter,
-		db,
-		nc,
-		logger,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error creating NodeSBOM store: %w", err)
-	}
-
-	nodeVulnerabilityReportStore, nodeVulnerabilityReportWatchers, err := storage.NewNodeVulnerabilityReportStore(
-		Scheme,
-		serverConfig.RESTOptionsGetter,
-		db,
-		nc,
-		logger,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error creating NodeVulnerabilityReport store: %w", err)
-	}
-
-	v1alpha1storage := map[string]rest.Storage{
-		"images":                   imageStore,
-		"sboms":                    sbomStore,
-		"vulnerabilityreports":     vulnerabilityReportStore,
-		"workloadscanreports":      workloadScanReportStore,
-		"nodesboms":                nodeSBOMStore,
-		"nodevulnerabilityreports": nodeVulnerabilityReportStore,
-	}
 	apiGroupInfo.VersionedResourcesStorageMap["v1alpha1"] = v1alpha1storage
 
 	if err := genericServer.InstallAPIGroup(&apiGroupInfo); err != nil {
@@ -225,11 +182,80 @@ func NewStorageAPIServer(db *pgxpool.Pool, nc *nats.Conn, logger *slog.Logger, c
 
 	return &StorageAPIServer{
 		db:                        db,
-		watchers:                  slices.Concat(imageWatchers, sbomWatchers, vulnerabilityReportWatchers, workloadScanReportWatchers, nodeSBOMWatchers, nodeVulnerabilityReportWatchers),
+		watchers:                  watchers,
 		logger:                    logger,
 		server:                    genericServer,
 		dynamicCertKeyPairContent: dynamicCertKeyPairContent,
 	}, nil
+}
+
+// buildHandlerChain wraps the default handler chain with otelhttp as the outermost handler,
+// so the server span covers the whole request and the trace context is extracted first.
+// Machinery requests (probes, discovery, OpenAPI aggregation) produce no spans.
+func buildHandlerChain(instrumentation *Instrumentation, servedResources sets.Set[string]) func(http.Handler, *genericapiserver.Config) http.Handler {
+	return func(apiHandler http.Handler, config *genericapiserver.Config) http.Handler {
+		// The duration filter sits inside the default chain, where the request
+		// info filter has already resolved the Kubernetes verb and resource.
+		handler := instrumentation.requestDurationFilter(apiHandler, config.LongRunningFunc, servedResources)
+		return otelhttp.NewHandler(
+			genericapiserver.DefaultBuildHandlerChain(handler, config),
+			"APIServer",
+			otelhttp.WithFilter(func(req *http.Request) bool {
+				return !isMachineryRequest(req)
+			}),
+		)
+	}
+}
+
+// buildStores creates the REST store and the watchers of every served resource.
+func buildStores(
+	optsGetter generic.RESTOptionsGetter,
+	db *pgxpool.Pool,
+	nc *nats.Conn,
+	instrumentation *storage.Instrumentation,
+	logger *slog.Logger,
+) (map[string]rest.Storage, []storage.Watcher, error) {
+	imageStore, imageWatchers, err := storage.NewImageStore(Scheme, optsGetter, db, nc, instrumentation, logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating Image store: %w", err)
+	}
+
+	sbomStore, sbomWatchers, err := storage.NewSBOMStore(Scheme, optsGetter, db, nc, instrumentation, logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating SBOM store: %w", err)
+	}
+
+	vulnerabilityReportStore, vulnerabilityReportWatchers, err := storage.NewVulnerabilityReportStore(Scheme, optsGetter, db, nc, instrumentation, logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating VulnerabilityReport store: %w", err)
+	}
+
+	workloadScanReportStore, workloadScanReportWatchers, err := storage.NewWorkloadScanReportStore(Scheme, optsGetter, db, nc, instrumentation, logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating WorkloadScanReport store: %w", err)
+	}
+
+	nodeSBOMStore, nodeSBOMWatchers, err := storage.NewNodeSBOMStore(Scheme, optsGetter, db, nc, instrumentation, logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating NodeSBOM store: %w", err)
+	}
+
+	nodeVulnerabilityReportStore, nodeVulnerabilityReportWatchers, err := storage.NewNodeVulnerabilityReportStore(Scheme, optsGetter, db, nc, instrumentation, logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating NodeVulnerabilityReport store: %w", err)
+	}
+
+	stores := map[string]rest.Storage{
+		"images":                   imageStore,
+		"sboms":                    sbomStore,
+		"vulnerabilityreports":     vulnerabilityReportStore,
+		"workloadscanreports":      workloadScanReportStore,
+		"nodesboms":                nodeSBOMStore,
+		"nodevulnerabilityreports": nodeVulnerabilityReportStore,
+	}
+	watchers := slices.Concat(imageWatchers, sbomWatchers, vulnerabilityReportWatchers, workloadScanReportWatchers, nodeSBOMWatchers, nodeVulnerabilityReportWatchers)
+
+	return stores, watchers, nil
 }
 
 func (s *StorageAPIServer) Start(ctx context.Context) error {

--- a/internal/storage/image_registry_store.go
+++ b/internal/storage/image_registry_store.go
@@ -43,6 +43,7 @@ func NewImageStore(
 	optsGetter generic.RESTOptionsGetter,
 	db *pgxpool.Pool,
 	nc *nats.Conn,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
 ) (*registry.Store, []Watcher, error) {
 	strategy := newImageStrategy(scheme)
@@ -52,7 +53,7 @@ func NewImageStore(
 	repo := repository.NewGenericObjectRepository(imageResourcePluralName, newFunc)
 
 	watchBroadcaster := watch.NewBroadcaster(1000, watch.WaitIfChannelFull)
-	natsBroadcaster := newNatsBroadcaster(nc, imageResourcePluralName, watchBroadcaster, TransformStripImage, logger)
+	natsBroadcaster := newNatsBroadcaster(nc, imageResourcePluralName, watchBroadcaster, TransformStripImage, instrumentation, logger)
 
 	store := &store{
 		db:          db,
@@ -63,7 +64,7 @@ func NewImageStore(
 		logger:      logger.With("store", imageResourceSingularName),
 	}
 
-	natsWatcher := newNatsWatcher(nc, imageResourcePluralName, watchBroadcaster, store, logger)
+	natsWatcher := newNatsWatcher(nc, imageResourcePluralName, watchBroadcaster, store, instrumentation, logger)
 
 	registryStore := &registry.Store{
 		NewFunc:                   newFunc,
@@ -72,7 +73,7 @@ func NewImageStore(
 		DefaultQualifiedResource:  storagev1alpha1.Resource(imageResourcePluralName),
 		SingularQualifiedResource: storagev1alpha1.Resource(imageResourceSingularName),
 		Storage: registry.DryRunnableStorage{
-			Storage: store,
+			Storage: instrumentStore(instrumentation, "ImageStore", store),
 		},
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/internal/storage/instrumentation.go
+++ b/internal/storage/instrumentation.go
@@ -1,0 +1,193 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// Bounded storage.result span attribute values.
+const (
+	storageResultSuccess       = "success"
+	storageResultNotFound      = "not_found"
+	storageResultAlreadyExists = "already_exists"
+	storageResultError         = "error"
+)
+
+// objectNameKey is the span attribute carrying the object name.
+// There is no OTel semantic convention for the name of an arbitrary Kubernetes object.
+const objectNameKey = attribute.Key("k8s.object.name")
+
+// Instrumentation bundles the tracer and the metric instruments shared by the stores
+// and the watch fan-out.
+// Disabled telemetry is represented by no-op providers.
+type Instrumentation struct {
+	tracer      trace.Tracer
+	watchEvents metric.Int64Counter
+}
+
+// NewInstrumentation creates a new Instrumentation.
+func NewInstrumentation(tracer trace.Tracer, meter metric.Meter) (*Instrumentation, error) {
+	watchEvents, err := meter.Int64Counter(
+		"storage.watch.events",
+		metric.WithDescription("Number of watch events distributed across the storage replicas."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating storage.watch.events counter: %w", err)
+	}
+
+	return &Instrumentation{
+		tracer:      tracer,
+		watchEvents: watchEvents,
+	}, nil
+}
+
+// startPublishSpan opens the producer span for one watch event publication.
+// The caller is responsible for ending the returned span.
+//
+//nolint:spancheck // The span deliberately outlives this helper.
+func (i *Instrumentation) startPublishSpan(ctx context.Context, subject string, eventType watch.EventType) (context.Context, trace.Span) {
+	return i.tracer.Start(ctx, "NatsBroadcaster.Publish",
+		trace.WithSpanKind(trace.SpanKindProducer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "nats"),
+			attribute.String("messaging.destination.name", subject),
+			attribute.String("event.type", strings.ToLower(string(eventType))),
+		),
+	)
+}
+
+// recordWatchEvent counts one watch event received by this replica.
+func (i *Instrumentation) recordWatchEvent(ctx context.Context, resource string, eventType watch.EventType) {
+	i.watchEvents.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("resource", resource),
+		attribute.String("event.type", strings.ToLower(string(eventType))),
+	))
+}
+
+// instrumentedStore decorates a store with a span per storage operation.
+type instrumentedStore struct {
+	*store
+
+	instrumentation *Instrumentation
+	component       string
+}
+
+// instrumentStore wraps inner so that every storage operation runs in a span
+// named <component>.<operation>.
+func instrumentStore(instrumentation *Instrumentation, component string, inner *store) *instrumentedStore {
+	return &instrumentedStore{
+		store:           inner,
+		instrumentation: instrumentation,
+		component:       component,
+	}
+}
+
+// startSpan opens the span for one storage operation.
+//
+//nolint:spancheck // The span deliberately outlives this helper.
+func (s *instrumentedStore) startSpan(ctx context.Context, operation, name, namespace string) (context.Context, trace.Span) {
+	attrs := make([]attribute.KeyValue, 0, 2)
+	if namespace != "" {
+		attrs = append(attrs, semconv.K8SNamespaceName(namespace))
+	}
+	if name != "" {
+		attrs = append(attrs, objectNameKey.String(name))
+	}
+
+	return s.instrumentation.tracer.Start(ctx, s.component+"."+operation,
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(attrs...),
+	)
+}
+
+// recordSpanResult classifies the operation outcome on the span.
+func recordSpanResult(span trace.Span, err error) {
+	result := storageResultSuccess
+	switch {
+	case err == nil:
+	case storage.IsNotFound(err):
+		result = storageResultNotFound
+	case storage.IsExist(err):
+		result = storageResultAlreadyExists
+	default:
+		result = storageResultError
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.SetAttributes(attribute.String("storage.result", result))
+}
+
+func (s *instrumentedStore) Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64) error {
+	name, namespace := s.extractKeyNameAndNamespace(key)
+	ctx, span := s.startSpan(ctx, "Create", name, namespace)
+	defer span.End()
+
+	err := s.store.Create(ctx, key, obj, out, ttl)
+	recordSpanResult(span, err)
+	return err
+}
+
+func (s *instrumentedStore) Delete(
+	ctx context.Context, key string, out runtime.Object, preconditions *storage.Preconditions,
+	validateDeletion storage.ValidateObjectFunc, cachedExistingObject runtime.Object, opts storage.DeleteOptions,
+) error {
+	name, namespace := s.extractKeyNameAndNamespace(key)
+	ctx, span := s.startSpan(ctx, "Delete", name, namespace)
+	defer span.End()
+
+	err := s.store.Delete(ctx, key, out, preconditions, validateDeletion, cachedExistingObject, opts)
+	recordSpanResult(span, err)
+	return err
+}
+
+func (s *instrumentedStore) Get(ctx context.Context, key string, opts storage.GetOptions, objPtr runtime.Object) error {
+	name, namespace := s.extractKeyNameAndNamespace(key)
+	ctx, span := s.startSpan(ctx, "Get", name, namespace)
+	defer span.End()
+
+	err := s.store.Get(ctx, key, opts, objPtr)
+	recordSpanResult(span, err)
+	return err
+}
+
+func (s *instrumentedStore) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
+	ctx, span := s.startSpan(ctx, "GetList", "", s.extractKeyNamespace(key))
+	defer span.End()
+
+	err := s.store.GetList(ctx, key, opts, listObj)
+	recordSpanResult(span, err)
+	return err
+}
+
+func (s *instrumentedStore) GuaranteedUpdate(
+	ctx context.Context, key string, destination runtime.Object, ignoreNotFound bool,
+	preconditions *storage.Preconditions, tryUpdate storage.UpdateFunc, cachedExistingObject runtime.Object,
+) error {
+	name, namespace := s.extractKeyNameAndNamespace(key)
+	ctx, span := s.startSpan(ctx, "GuaranteedUpdate", name, namespace)
+	defer span.End()
+
+	err := s.store.GuaranteedUpdate(ctx, key, destination, ignoreNotFound, preconditions, tryUpdate, cachedExistingObject)
+	recordSpanResult(span, err)
+	return err
+}
+
+// Watch spans only cover the watch setup; the returned stream outlives the span.
+func (s *instrumentedStore) Watch(ctx context.Context, key string, opts storage.ListOptions) (watch.Interface, error) {
+	ctx, span := s.startSpan(ctx, "Watch", "", s.extractKeyNamespace(key))
+	defer span.End()
+
+	watcher, err := s.store.Watch(ctx, key, opts)
+	recordSpanResult(span, err)
+	return watcher, err
+}

--- a/internal/storage/instrumentation_test.go
+++ b/internal/storage/instrumentation_test.go
@@ -1,0 +1,161 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/storage"
+
+	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
+	"github.com/kubewarden/sbomscanner/internal/storage/repository"
+)
+
+// fakeRepository serves Get from a canned object or error; the other methods are unused.
+type fakeRepository struct {
+	repository.Repository
+
+	getObject runtime.Object
+	getErr    error
+}
+
+func (f *fakeRepository) Get(_ context.Context, _ repository.Querier, _, _ string) (runtime.Object, error) {
+	return f.getObject, f.getErr
+}
+
+func (f *fakeRepository) Delete(_ context.Context, _ pgx.Tx, _, _ string) (runtime.Object, error) {
+	return f.getObject, f.getErr
+}
+
+func newTestInstrumentedStore(t *testing.T, repo repository.Repository) (*instrumentedStore, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		require.NoError(t, tracerProvider.Shutdown(context.Background()))
+	})
+
+	inner := &store{
+		repository: repo,
+		newFunc:    func() runtime.Object { return &storagev1alpha1.Image{} },
+		logger:     slog.New(slog.DiscardHandler),
+	}
+
+	instrumentation, err := NewInstrumentation(tracerProvider.Tracer("test"), metricnoop.NewMeterProvider().Meter("test"))
+	require.NoError(t, err)
+
+	return instrumentStore(instrumentation, "ImageStore", inner), spanRecorder
+}
+
+func attributeMap(span sdktrace.ReadOnlySpan) map[attribute.Key]attribute.Value {
+	attrs := make(map[attribute.Key]attribute.Value, len(span.Attributes()))
+	for _, kv := range span.Attributes() {
+		attrs[kv.Key] = kv.Value
+	}
+	return attrs
+}
+
+// TestRecordSpanResult asserts the outcome classification on the span:
+// expected outcomes are attributes, only unexpected failures mark the span as errored.
+func TestRecordSpanResult(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		result     string
+		statusCode codes.Code
+		hasEvents  bool
+	}{
+		{name: "success", err: nil, result: storageResultSuccess, statusCode: codes.Unset},
+		{name: "not found", err: storage.NewKeyNotFoundError("key", 0), result: storageResultNotFound, statusCode: codes.Unset},
+		{name: "already exists", err: storage.NewKeyExistsError("key", 0), result: storageResultAlreadyExists, statusCode: codes.Unset},
+		{name: "internal error", err: errors.New("connection reset"), result: storageResultError, statusCode: codes.Error, hasEvents: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spanRecorder := tracetest.NewSpanRecorder()
+			tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+			t.Cleanup(func() {
+				require.NoError(t, tracerProvider.Shutdown(context.Background()))
+			})
+
+			_, span := tracerProvider.Tracer("test").Start(context.Background(), "operation")
+			recordSpanResult(span, test.err)
+			span.End()
+
+			spans := spanRecorder.Ended()
+			require.Len(t, spans, 1)
+			attrs := attributeMap(spans[0])
+			assert.Equal(t, test.result, attrs["storage.result"].AsString())
+			assert.Equal(t, test.statusCode, spans[0].Status().Code)
+			assert.Equal(t, test.hasEvents, len(spans[0].Events()) > 0)
+		})
+	}
+}
+
+// TestInstrumentedStore_GetSuccess asserts the span name, the identity attributes
+// parsed from the key, and the success result.
+func TestInstrumentedStore_GetSuccess(t *testing.T) {
+	instrumented, spanRecorder := newTestInstrumentedStore(t, &fakeRepository{getObject: &storagev1alpha1.Image{}})
+
+	objPtr := &storagev1alpha1.Image{}
+	err := instrumented.Get(context.Background(), "/storage.sbomscanner.kubewarden.io/images/default/my-image", storage.GetOptions{}, objPtr)
+	require.NoError(t, err)
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "ImageStore.Get", spans[0].Name())
+
+	attrs := attributeMap(spans[0])
+	assert.Equal(t, "default", attrs["k8s.namespace.name"].AsString())
+	assert.Equal(t, "my-image", attrs["k8s.object.name"].AsString())
+	assert.Equal(t, storageResultSuccess, attrs["storage.result"].AsString())
+	assert.Equal(t, codes.Unset, spans[0].Status().Code)
+}
+
+// TestInstrumentedStore_GetNotFound asserts that a missing object is an expected
+// outcome: recorded on the result attribute, not as a span error.
+func TestInstrumentedStore_GetNotFound(t *testing.T) {
+	instrumented, spanRecorder := newTestInstrumentedStore(t, &fakeRepository{getErr: repository.ErrNotFound})
+
+	objPtr := &storagev1alpha1.Image{}
+	err := instrumented.Get(context.Background(), "/storage.sbomscanner.kubewarden.io/images/default/my-image", storage.GetOptions{}, objPtr)
+	require.Error(t, err)
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+
+	attrs := attributeMap(spans[0])
+	assert.Equal(t, storageResultNotFound, attrs["storage.result"].AsString())
+	assert.Equal(t, codes.Unset, spans[0].Status().Code)
+	assert.Empty(t, spans[0].Events(), "no error event expected for a not found outcome")
+}
+
+// TestInstrumentedStore_GetInternalError asserts that an unexpected failure marks
+// the span as errored and records the error event.
+func TestInstrumentedStore_GetInternalError(t *testing.T) {
+	instrumented, spanRecorder := newTestInstrumentedStore(t, &fakeRepository{getErr: errors.New("connection reset")})
+
+	objPtr := &storagev1alpha1.Image{}
+	err := instrumented.Get(context.Background(), "/storage.sbomscanner.kubewarden.io/images/default/my-image", storage.GetOptions{}, objPtr)
+	require.Error(t, err)
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+
+	attrs := attributeMap(spans[0])
+	assert.Equal(t, storageResultError, attrs["storage.result"].AsString())
+	assert.Equal(t, codes.Error, spans[0].Status().Code)
+	assert.NotEmpty(t, spans[0].Events(), "error event expected")
+}

--- a/internal/storage/node_sbom_store.go
+++ b/internal/storage/node_sbom_store.go
@@ -45,6 +45,7 @@ func NewNodeSBOMStore(
 	optsGetter generic.RESTOptionsGetter,
 	db *pgxpool.Pool,
 	nc *nats.Conn,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
 ) (*registry.Store, []Watcher, error) {
 	strategy := newNodeSBOMStrategy(scheme)
@@ -52,7 +53,7 @@ func NewNodeSBOMStore(
 	newListFunc := func() runtime.Object { return &storagev1alpha1.NodeSBOMList{} }
 
 	watchBroadcaster := watch.NewBroadcaster(1000, watch.WaitIfChannelFull)
-	natsBroadcaster := newNatsBroadcaster(nc, nodeSBOMResourcePluralName, watchBroadcaster, TransformStripNodeSBOM, logger)
+	natsBroadcaster := newNatsBroadcaster(nc, nodeSBOMResourcePluralName, watchBroadcaster, TransformStripNodeSBOM, instrumentation, logger)
 
 	repo := repository.NewGenericObjectRepository(nodeSBOMResourcePluralName, newFunc)
 
@@ -66,7 +67,7 @@ func NewNodeSBOMStore(
 		clusterScoped: true,
 	}
 
-	natsWatcher := newNatsWatcher(nc, nodeSBOMResourcePluralName, watchBroadcaster, store, logger)
+	natsWatcher := newNatsWatcher(nc, nodeSBOMResourcePluralName, watchBroadcaster, store, instrumentation, logger)
 
 	registryStore := &registry.Store{
 		NewFunc:                   newFunc,
@@ -75,7 +76,7 @@ func NewNodeSBOMStore(
 		DefaultQualifiedResource:  storagev1alpha1.Resource(nodeSBOMResourcePluralName),
 		SingularQualifiedResource: storagev1alpha1.Resource(nodeSBOMResourceSingularName),
 		Storage: registry.DryRunnableStorage{
-			Storage: store,
+			Storage: instrumentStore(instrumentation, "NodeSBOMStore", store),
 		},
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/internal/storage/nodevulnerabilityreport_store.go
+++ b/internal/storage/nodevulnerabilityreport_store.go
@@ -45,6 +45,7 @@ func NewNodeVulnerabilityReportStore(
 	optsGetter generic.RESTOptionsGetter,
 	db *pgxpool.Pool,
 	nc *nats.Conn,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
 ) (*registry.Store, []Watcher, error) {
 	strategy := newNodeVulnerabilityReportStrategy(scheme)
@@ -52,7 +53,7 @@ func NewNodeVulnerabilityReportStore(
 	newListFunc := func() runtime.Object { return &storagev1alpha1.NodeVulnerabilityReportList{} }
 
 	watchBroadcaster := watch.NewBroadcaster(1000, watch.WaitIfChannelFull)
-	natsBroadcaster := newNatsBroadcaster(nc, nodeVulnerabilityReportResourcePluralName, watchBroadcaster, TransformStripNodeVulnerabilityReport, logger)
+	natsBroadcaster := newNatsBroadcaster(nc, nodeVulnerabilityReportResourcePluralName, watchBroadcaster, TransformStripNodeVulnerabilityReport, instrumentation, logger)
 
 	repo := repository.NewGenericObjectRepository(nodeVulnerabilityReportResourcePluralName, newFunc)
 
@@ -66,7 +67,7 @@ func NewNodeVulnerabilityReportStore(
 		clusterScoped: true,
 	}
 
-	natsWatcher := newNatsWatcher(nc, nodeVulnerabilityReportResourcePluralName, watchBroadcaster, store, logger)
+	natsWatcher := newNatsWatcher(nc, nodeVulnerabilityReportResourcePluralName, watchBroadcaster, store, instrumentation, logger)
 
 	registryStore := &registry.Store{
 		NewFunc:                   newFunc,
@@ -75,7 +76,7 @@ func NewNodeVulnerabilityReportStore(
 		DefaultQualifiedResource:  storagev1alpha1.Resource(nodeVulnerabilityReportResourcePluralName),
 		SingularQualifiedResource: storagev1alpha1.Resource(nodeVulnerabilityReportResourceSingularName),
 		Storage: registry.DryRunnableStorage{
-			Storage: store,
+			Storage: instrumentStore(instrumentation, "NodeVulnerabilityReportStore", store),
 		},
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/internal/storage/sbom_registry_store.go
+++ b/internal/storage/sbom_registry_store.go
@@ -43,6 +43,7 @@ func NewSBOMStore(
 	optsGetter generic.RESTOptionsGetter,
 	db *pgxpool.Pool,
 	nc *nats.Conn,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
 ) (*registry.Store, []Watcher, error) {
 	strategy := newSBOMStrategy(scheme)
@@ -50,7 +51,7 @@ func NewSBOMStore(
 	newListFunc := func() runtime.Object { return &storagev1alpha1.SBOMList{} }
 
 	watchBroadcaster := watch.NewBroadcaster(1000, watch.WaitIfChannelFull)
-	natsBroadcaster := newNatsBroadcaster(nc, sbomResourcePluralName, watchBroadcaster, TransformStripSBOM, logger)
+	natsBroadcaster := newNatsBroadcaster(nc, sbomResourcePluralName, watchBroadcaster, TransformStripSBOM, instrumentation, logger)
 
 	repo := repository.NewGenericObjectRepository(sbomResourcePluralName, newFunc)
 
@@ -63,7 +64,7 @@ func NewSBOMStore(
 		logger:      logger.With("store", sbomResourceSingularName),
 	}
 
-	natsWatcher := newNatsWatcher(nc, sbomResourcePluralName, watchBroadcaster, store, logger)
+	natsWatcher := newNatsWatcher(nc, sbomResourcePluralName, watchBroadcaster, store, instrumentation, logger)
 
 	registryStore := &registry.Store{
 		NewFunc:                   newFunc,
@@ -72,7 +73,7 @@ func NewSBOMStore(
 		DefaultQualifiedResource:  storagev1alpha1.Resource(sbomResourcePluralName),
 		SingularQualifiedResource: storagev1alpha1.Resource(sbomResourceSingularName),
 		Storage: registry.DryRunnableStorage{
-			Storage: store,
+			Storage: instrumentStore(instrumentation, "SBOMStore", store),
 		},
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -115,7 +115,7 @@ func (s *store) Create(ctx context.Context, key string, obj, out runtime.Object,
 		return storage.NewInternalError(err)
 	}
 
-	if err := s.broadcaster.Action(watch.Added, obj); err != nil {
+	if err := s.broadcaster.Action(ctx, watch.Added, obj); err != nil {
 		s.logger.ErrorContext(ctx, "failed to broadcast add action", "error", err)
 	}
 
@@ -174,7 +174,7 @@ func (s *store) Delete(
 		return storage.NewInternalError(err)
 	}
 
-	if err := s.broadcaster.Action(watch.Deleted, obj); err != nil {
+	if err := s.broadcaster.Action(ctx, watch.Deleted, obj); err != nil {
 		s.logger.ErrorContext(ctx, "failed to broadcast delete action", "error", err)
 	}
 
@@ -540,7 +540,7 @@ func (s *store) GuaranteedUpdate(
 			return storage.NewInternalError(err)
 		}
 
-		if err := s.broadcaster.Action(watch.Modified, updatedObj); err != nil {
+		if err := s.broadcaster.Action(ctx, watch.Modified, updatedObj); err != nil {
 			s.logger.ErrorContext(ctx, "failed to broadcast modified action", "error", err)
 		}
 

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -59,7 +59,7 @@ type storeTestSuite struct {
 	suite.Suite
 
 	test        storeTestCase
-	store       *store
+	store       *instrumentedStore
 	db          *pgxpool.Pool
 	broadcaster *watch.Broadcaster
 	watcher     *natsWatcher
@@ -130,7 +130,7 @@ func (suite *storeTestSuite) SetupTest() {
 	repo := repository.NewGenericObjectRepository(suite.test.resource, suite.test.newFunc)
 
 	watchBroadcaster := watch.NewBroadcaster(1000, watch.WaitIfChannelFull)
-	natsBroadcaster := newNatsBroadcaster(suite.nc, suite.test.resource, watchBroadcaster, suite.test.transform, slog.Default())
+	natsBroadcaster := newNatsBroadcaster(suite.nc, suite.test.resource, watchBroadcaster, suite.test.transform, noopInstrumentation(suite.T()), slog.Default())
 
 	store := &store{
 		db:            suite.db,
@@ -141,9 +141,10 @@ func (suite *storeTestSuite) SetupTest() {
 		logger:        slog.Default(),
 		clusterScoped: suite.test.clusterScoped,
 	}
-	natsWatcher := newNatsWatcher(suite.nc, suite.test.resource, watchBroadcaster, store, slog.Default())
+	natsWatcher := newNatsWatcher(suite.nc, suite.test.resource, watchBroadcaster, store, noopInstrumentation(suite.T()), slog.Default())
 
-	suite.store = store
+	// Route the suite through the decorator, as production always does.
+	suite.store = instrumentStore(noopInstrumentation(suite.T()), "TestStore", store)
 	suite.broadcaster = watchBroadcaster
 	suite.watcher = natsWatcher
 }

--- a/internal/storage/utils_test.go
+++ b/internal/storage/utils_test.go
@@ -5,8 +5,22 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
 	"k8s.io/apimachinery/pkg/watch"
 )
+
+// noopInstrumentation returns an Instrumentation backed by no-op providers.
+func noopInstrumentation(t *testing.T) *Instrumentation {
+	t.Helper()
+
+	instrumentation, err := NewInstrumentation(
+		tracenoop.NewTracerProvider().Tracer("test"),
+		metricnoop.NewMeterProvider().Meter("test"),
+	)
+	require.NoError(t, err)
+	return instrumentation
+}
 
 // mustReadEvents reads n events from the watch.Interface or fails the test if not enough events are received in time.
 func mustReadEvents(t *testing.T, w watch.Interface, n int) []watch.Event {

--- a/internal/storage/vulnerabilityreport_registry_store.go
+++ b/internal/storage/vulnerabilityreport_registry_store.go
@@ -43,6 +43,7 @@ func NewVulnerabilityReportStore(
 	optsGetter generic.RESTOptionsGetter,
 	db *pgxpool.Pool,
 	nc *nats.Conn,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
 ) (*registry.Store, []Watcher, error) {
 	strategy := newVulnerabilityReportStrategy(scheme)
@@ -53,7 +54,7 @@ func NewVulnerabilityReportStore(
 	repo := repository.NewGenericObjectRepository(vulnerabilityReportResourcePluralName, newFunc)
 
 	watchBroadcaster := watch.NewBroadcaster(1000, watch.WaitIfChannelFull)
-	natsBroadcaster := newNatsBroadcaster(nc, vulnerabilityReportResourcePluralName, watchBroadcaster, TransformStripVulnerabilityReport, logger)
+	natsBroadcaster := newNatsBroadcaster(nc, vulnerabilityReportResourcePluralName, watchBroadcaster, TransformStripVulnerabilityReport, instrumentation, logger)
 
 	store := &store{
 		db:          db,
@@ -63,7 +64,7 @@ func NewVulnerabilityReportStore(
 		newListFunc: newListFunc,
 		logger:      logger.With("store", vulnerabilityReportResourceSingularName),
 	}
-	natsWatcher := newNatsWatcher(nc, vulnerabilityReportResourcePluralName, watchBroadcaster, store, logger)
+	natsWatcher := newNatsWatcher(nc, vulnerabilityReportResourcePluralName, watchBroadcaster, store, instrumentation, logger)
 
 	registryStore := &registry.Store{
 		NewFunc:                   newFunc,
@@ -72,7 +73,7 @@ func NewVulnerabilityReportStore(
 		DefaultQualifiedResource:  storagev1alpha1.Resource(vulnerabilityReportResourcePluralName),
 		SingularQualifiedResource: storagev1alpha1.Resource(vulnerabilityReportResourceSingularName),
 		Storage: registry.DryRunnableStorage{
-			Storage: store,
+			Storage: instrumentStore(instrumentation, "VulnerabilityReportStore", store),
 		},
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/internal/storage/watcher.go
+++ b/internal/storage/watcher.go
@@ -6,8 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -16,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
 )
 
 // event is the payload sent via NATS for watch events.
@@ -37,6 +42,7 @@ type natsWatcher struct {
 	subject          string
 	resource         string
 	watchBroadcaster *watch.Broadcaster
+	instrumentation  *Instrumentation
 	logger           *slog.Logger
 	store            *store
 	sub              *nats.Subscription
@@ -46,6 +52,7 @@ func newNatsWatcher(nc *nats.Conn,
 	resource string,
 	watchBroadcaster *watch.Broadcaster,
 	store *store,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
 ) *natsWatcher {
 	subject := fmt.Sprintf("watch.%s", resource)
@@ -56,6 +63,7 @@ func newNatsWatcher(nc *nats.Conn,
 		subject:          subject,
 		watchBroadcaster: watchBroadcaster,
 		store:            store,
+		instrumentation:  instrumentation,
 		logger:           logger.With("component", "nats-watcher", "subject", subject),
 	}
 }
@@ -110,16 +118,42 @@ func (w *natsWatcher) Start(ctx context.Context) error {
 	return nil
 }
 
-// handleMessage processes a NATS message and broadcasts it locally.
+// handleMessage runs one consumed watch event in a consumer span.
+// The span joins the trace of the write that published the event.
 func (w *natsWatcher) handleMessage(ctx context.Context, msg *nats.Msg) error {
+	ctx = telemetry.ExtractNATS(ctx, msg.Header)
+	ctx, span := w.instrumentation.tracer.Start(ctx, "NatsWatcher.HandleMessage",
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "nats"),
+			attribute.String("messaging.destination.name", w.subject),
+		),
+	)
+	defer span.End()
+
+	eventType, err := w.processMessage(ctx, msg)
+	if eventType != "" {
+		span.SetAttributes(attribute.String("event.type", strings.ToLower(string(eventType))))
+		w.instrumentation.recordWatchEvent(ctx, w.resource, eventType)
+	}
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	return err
+}
+
+// processMessage decodes a NATS message and broadcasts it locally.
+// It returns the event type as soon as it is known, even on failure.
+func (w *natsWatcher) processMessage(ctx context.Context, msg *nats.Msg) (watch.EventType, error) {
 	var payload event
 	if err := json.Unmarshal(msg.Data, &payload); err != nil {
-		return fmt.Errorf("failed to unmarshal payload: %w", err)
+		return "", fmt.Errorf("failed to unmarshal payload: %w", err)
 	}
 
 	obj := w.store.newFunc()
 	if err := json.Unmarshal(payload.Object.Raw, obj); err != nil {
-		return fmt.Errorf("failed to decode object: %w", err)
+		return payload.EventType, fmt.Errorf("failed to decode object: %w", err)
 	}
 
 	// For deleted events broadcast the payload directly since the store no longer has it.
@@ -127,20 +161,20 @@ func (w *natsWatcher) handleMessage(ctx context.Context, msg *nats.Msg) error {
 	if payload.EventType != watch.Deleted {
 		rehydrated, err := w.rehydrate(ctx, obj)
 		if err != nil {
-			return err
+			return payload.EventType, err
 		}
 		obj = rehydrated
 	}
 
 	if err := w.watchBroadcaster.Action(payload.EventType, obj); err != nil {
-		return fmt.Errorf("failed to broadcast action while handling message: %w", err)
+		return payload.EventType, fmt.Errorf("failed to broadcast action while handling message: %w", err)
 	}
 
 	w.logger.DebugContext(ctx, "Broadcasted watch event",
 		"type", payload.EventType,
 		"obj", payload.Object,
 	)
-	return nil
+	return payload.EventType, nil
 }
 
 // rehydrate returns the stored object matching the payload, or the payload itself when the store does not hold a matching object.
@@ -190,6 +224,7 @@ type natsBroadcaster struct {
 	nc               *nats.Conn
 	subject          string
 	watchBroadcaster *watch.Broadcaster
+	instrumentation  *Instrumentation
 	logger           *slog.Logger
 	transform        cache.TransformFunc
 }
@@ -198,6 +233,7 @@ func newNatsBroadcaster(nc *nats.Conn,
 	resource string,
 	watchBroadcaster *watch.Broadcaster,
 	transform cache.TransformFunc,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
 ) *natsBroadcaster {
 	subject := fmt.Sprintf("watch.%s", resource)
@@ -207,6 +243,7 @@ func newNatsBroadcaster(nc *nats.Conn,
 		subject:          subject,
 		watchBroadcaster: watchBroadcaster,
 		transform:        transform,
+		instrumentation:  instrumentation,
 		logger:           logger.With("component", "nats-broadcaster", "subject", subject),
 	}
 }
@@ -231,8 +268,22 @@ func (b *natsBroadcaster) WatchWithPrefix(events []watch.Event) (watch.Interface
 	return watch, nil
 }
 
-// Action broadcasts an event to all local watchers.
-func (b *natsBroadcaster) Action(eventType watch.EventType, obj runtime.Object) error {
+// Action publishes an event to NATS so every storage replica rebroadcasts it locally.
+// The message headers carry the trace context of the write that produced the event.
+func (b *natsBroadcaster) Action(ctx context.Context, eventType watch.EventType, obj runtime.Object) error {
+	ctx, span := b.instrumentation.startPublishSpan(ctx, b.subject, eventType)
+	defer span.End()
+
+	err := b.publish(ctx, eventType, obj)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	return err
+}
+
+// publish transforms, marshals, and publishes one watch event to NATS.
+func (b *natsBroadcaster) publish(ctx context.Context, eventType watch.EventType, obj runtime.Object) error {
 	t, err := b.transform(obj.DeepCopyObject())
 	if err != nil {
 		return fmt.Errorf("failed to transform object: %w", err)
@@ -255,11 +306,17 @@ func (b *natsBroadcaster) Action(eventType watch.EventType, obj runtime.Object) 
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
-	if err := b.nc.Publish(b.subject, payloadBytes); err != nil {
+
+	msg := &nats.Msg{
+		Subject: b.subject,
+		Data:    payloadBytes,
+	}
+	telemetry.InjectNATS(ctx, msg)
+	if err := b.nc.PublishMsg(msg); err != nil {
 		return fmt.Errorf("publish to NATS: %w", err)
 	}
 
-	b.logger.Debug("Published watch event to NATS", "eventType", eventType, "object", transformedObj)
+	b.logger.DebugContext(ctx, "Published watch event to NATS", "eventType", eventType, "object", transformedObj)
 
 	return nil
 }

--- a/internal/storage/workloadscanreport_registry_store.go
+++ b/internal/storage/workloadscanreport_registry_store.go
@@ -39,6 +39,7 @@ func NewWorkloadScanReportStore(
 	optsGetter generic.RESTOptionsGetter,
 	db *pgxpool.Pool,
 	nc *nats.Conn,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
 ) (*registry.Store, []Watcher, error) {
 	strategy := newWorkloadScanReportStrategy(scheme)
@@ -49,7 +50,7 @@ func NewWorkloadScanReportStore(
 	repo := repository.NewWorkloadScanReportRepository(workloadScanReportResourcePluralName, vulnerabilityReportResourcePluralName, imageResourcePluralName)
 
 	watchBroadcaster := watch.NewBroadcaster(1000, watch.WaitIfChannelFull)
-	natsBroadcaster := newNatsBroadcaster(nc, workloadScanReportResourcePluralName, watchBroadcaster, TransformStripWorkloadScanReport, logger)
+	natsBroadcaster := newNatsBroadcaster(nc, workloadScanReportResourcePluralName, watchBroadcaster, TransformStripWorkloadScanReport, instrumentation, logger)
 
 	store := &store{
 		db:          db,
@@ -60,7 +61,7 @@ func NewWorkloadScanReportStore(
 		logger:      logger.With("store", workloadScanReportResourceSingularName),
 	}
 
-	natsWatcher := newNatsWatcher(nc, workloadScanReportResourcePluralName, watchBroadcaster, store, logger)
+	natsWatcher := newNatsWatcher(nc, workloadScanReportResourcePluralName, watchBroadcaster, store, instrumentation, logger)
 
 	workloadScanReportWatcher := newWorkloadScanReportWatcher(
 		nc,
@@ -68,6 +69,7 @@ func NewWorkloadScanReportStore(
 		repo,
 		natsBroadcaster,
 		store,
+		instrumentation,
 		logger,
 	)
 
@@ -78,7 +80,7 @@ func NewWorkloadScanReportStore(
 		DefaultQualifiedResource:  storagev1alpha1.Resource(workloadScanReportResourcePluralName),
 		SingularQualifiedResource: storagev1alpha1.Resource(workloadScanReportResourceSingularName),
 		Storage: registry.DryRunnableStorage{
-			Storage: store,
+			Storage: instrumentStore(instrumentation, "WorkloadScanReportStore", store),
 		},
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/internal/storage/workloadscanreport_watcher.go
+++ b/internal/storage/workloadscanreport_watcher.go
@@ -9,11 +9,15 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/watch"
 
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/storage/repository"
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
 )
 
 // WorkloadScanReportWatcher watches VulnerabilityReport events and generates
@@ -25,6 +29,7 @@ type WorkloadScanReportWatcher struct {
 	repo                    *repository.WorkloadScanReportRepository
 	workloadBroadcaster     *natsBroadcaster
 	workloadScanReportStore *store
+	instrumentation         *Instrumentation
 	logger                  *slog.Logger
 	sub                     *nats.Subscription
 }
@@ -35,6 +40,7 @@ func newWorkloadScanReportWatcher(
 	repo *repository.WorkloadScanReportRepository,
 	workloadBroadcaster *natsBroadcaster,
 	workloadScanReportStore *store,
+	instrumentation *Instrumentation,
 	logger *slog.Logger,
 ) *WorkloadScanReportWatcher {
 	return &WorkloadScanReportWatcher{
@@ -43,6 +49,7 @@ func newWorkloadScanReportWatcher(
 		repo:                    repo,
 		workloadBroadcaster:     workloadBroadcaster,
 		workloadScanReportStore: workloadScanReportStore,
+		instrumentation:         instrumentation,
 		logger:                  logger.With("component", "workloadscanreport-watcher"),
 	}
 }
@@ -100,7 +107,30 @@ func (w *WorkloadScanReportWatcher) Start(ctx context.Context) error {
 	return nil
 }
 
+// handleVulnerabilityReportEvent runs one consumed event in a consumer span.
+// The span joins the trace of the VulnerabilityReport write that published the event.
 func (w *WorkloadScanReportWatcher) handleVulnerabilityReportEvent(ctx context.Context, msg *nats.Msg) error {
+	ctx = telemetry.ExtractNATS(ctx, msg.Header)
+	ctx, span := w.instrumentation.tracer.Start(ctx, "WorkloadScanReportWatcher.HandleVulnerabilityReportEvent",
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "nats"),
+			attribute.String("messaging.destination.name", "watch."+vulnerabilityReportResourcePluralName),
+		),
+	)
+	defer span.End()
+
+	err := w.processVulnerabilityReportEvent(ctx, msg)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	return err
+}
+
+// processVulnerabilityReportEvent fans a VulnerabilityReport event out as synthetic
+// MODIFIED events for every WorkloadScanReport referencing the changed report.
+func (w *WorkloadScanReportWatcher) processVulnerabilityReportEvent(ctx context.Context, msg *nats.Msg) error {
 	var payload event
 	if err := json.Unmarshal(msg.Data, &payload); err != nil {
 		return fmt.Errorf("failed to unmarshal payload: %w", err)
@@ -150,7 +180,7 @@ func (w *WorkloadScanReportWatcher) handleVulnerabilityReportEvent(ctx context.C
 			"vulnReportEvent", payload.EventType,
 		)
 
-		if err := w.workloadBroadcaster.Action(watch.Modified, &report); err != nil {
+		if err := w.workloadBroadcaster.Action(ctx, watch.Modified, &report); err != nil {
 			w.logger.ErrorContext(ctx, "Failed to broadcast WorkloadScanReport event",
 				"error", err,
 				"name", metaAccessor.GetName(),

--- a/internal/storage/workloadscanreport_watcher_test.go
+++ b/internal/storage/workloadscanreport_watcher_test.go
@@ -108,6 +108,7 @@ func (suite *workloadScanReportWatcherTestSuite) SetupTest() {
 		"workloadscanreports",
 		suite.localBroadcaster,
 		TransformStripWorkloadScanReport,
+		noopInstrumentation(suite.T()),
 		slog.Default(),
 	)
 
@@ -125,6 +126,7 @@ func (suite *workloadScanReportWatcherTestSuite) SetupTest() {
 		"workloadscanreports",
 		suite.localBroadcaster,
 		suite.workloadStore,
+		noopInstrumentation(suite.T()),
 		slog.Default(),
 	)
 }
@@ -156,6 +158,7 @@ func (suite *workloadScanReportWatcherTestSuite) TestNoMatchingWorkloadScanRepor
 		suite.repo,
 		suite.workloadBroadcaster,
 		suite.workloadStore,
+		noopInstrumentation(suite.T()),
 		slog.Default(),
 	)
 	suite.Require().NoError(watcher.Setup(ctx))
@@ -227,6 +230,7 @@ func (suite *workloadScanReportWatcherTestSuite) TestMultipleWorkloadScanReports
 		suite.repo,
 		suite.workloadBroadcaster,
 		suite.workloadStore,
+		noopInstrumentation(suite.T()),
 		slog.Default(),
 	)
 	suite.Require().NoError(watcher.Setup(ctx))

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -16,6 +16,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
 )
 
 // ShutdownFunc flushes and stops the providers installed by Setup.
@@ -62,7 +64,14 @@ func WithMetricProducer(producer sdkmetric.Producer) Option {
 //
 // serviceName and serviceVersion populate the standard resource attributes,
 // and are overridable via OTEL_SERVICE_NAME / OTEL_RESOURCE_ATTRIBUTES.
-func Setup(ctx context.Context, serviceName, serviceVersion string, opts ...Option) (ShutdownFunc, error) {
+//
+// The returned tracer provider instruments Kubernetes API clients
+// (pass it to the upstream k8s.io/component-base/tracing.WrapperFor):
+// API calls made inside a sampled span produce child client spans,
+// while calls outside any trace produce nothing instead of one-span root traces.
+// When telemetry is disabled it is a no-op provider,
+// which used with otelhttp still propagates an existing trace context.
+func Setup(ctx context.Context, serviceName, serviceVersion string, opts ...Option) (ShutdownFunc, trace.TracerProvider, error) {
 	// Always install W3C propagators so application code can call otel.GetTextMapPropagator() without branching on whether export is enabled.
 	// Propagation through NATS headers (see nats.go) is a pure in-process concern and works even with no-op providers.
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
@@ -73,17 +82,17 @@ func Setup(ctx context.Context, serviceName, serviceVersion string, opts ...Opti
 	if os.Getenv(envOTLPEndpoint) == "" {
 		// No-op shutdown.
 		// The default global TracerProvider and MeterProvider are already no-op implementations.
-		return func(context.Context) error { return nil }, nil
+		return func(context.Context) error { return nil }, tracenoop.NewTracerProvider(), nil
 	}
 
 	res, err := buildResource(ctx, serviceName, serviceVersion)
 	if err != nil {
-		return nil, fmt.Errorf("building otel resource: %w", err)
+		return nil, nil, fmt.Errorf("building otel resource: %w", err)
 	}
 
 	traceExporter, err := otlptracegrpc.New(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("creating OTLP trace exporter: %w", err)
+		return nil, nil, fmt.Errorf("creating OTLP trace exporter: %w", err)
 	}
 
 	// Histograms default to base2 exponential aggregation: bucket resolution adapts
@@ -100,17 +109,25 @@ func Setup(ctx context.Context, serviceName, serviceVersion string, opts ...Opti
 		// The rollback error (if any) is joined onto the returned error, never dropped.
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		return nil, errors.Join(
+		return nil, nil, errors.Join(
 			fmt.Errorf("creating OTLP metric exporter: %w", err),
 			traceExporter.Shutdown(shutdownCtx),
 		)
 	}
 
+	// Both tracer providers share the processor; its Shutdown is idempotent.
+	spanProcessor := sdktrace.NewBatchSpanProcessor(traceExporter)
 	tracerProvider := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(traceExporter),
+		sdktrace.WithSpanProcessor(spanProcessor),
 		sdktrace.WithResource(res),
 	)
 	otel.SetTracerProvider(tracerProvider)
+
+	clientProvider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(spanProcessor),
+		sdktrace.WithResource(res),
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.NeverSample())),
+	)
 
 	var config setupConfig
 	for _, opt := range opts {
@@ -128,14 +145,15 @@ func Setup(ctx context.Context, serviceName, serviceVersion string, opts ...Opti
 	otel.SetMeterProvider(meterProvider)
 
 	shutdown := func(ctx context.Context) error {
-		// Best-effort: try both, surface both errors.
+		// Best-effort: try all, surface every error.
 		return errors.Join(
 			tracerProvider.Shutdown(ctx),
+			clientProvider.Shutdown(ctx),
 			meterProvider.Shutdown(ctx),
 		)
 	}
 
-	return shutdown, nil
+	return shutdown, clientProvider, nil
 }
 
 // histogramAggregationSelector aggregates histograms as base2 exponential histograms

--- a/internal/telemetry/otel_test.go
+++ b/internal/telemetry/otel_test.go
@@ -23,9 +23,10 @@ import (
 func TestSetup_NoEndpoint(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 
-	shutdown, err := Setup(context.Background(), "test-service", "v0.0.0")
+	shutdown, clientTracerProvider, err := Setup(context.Background(), "test-service", "v0.0.0")
 	require.NoError(t, err)
 	require.NotNil(t, shutdown)
+	require.NotNil(t, clientTracerProvider)
 
 	// Composite W3C propagator should be installed even in no-op mode.
 	prop := otel.GetTextMapPropagator()
@@ -44,9 +45,10 @@ func TestSetup_WithEndpoint(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "100")
 	t.Cleanup(resetGlobalProviders)
 
-	shutdown, err := Setup(context.Background(), "test-service", "v0.0.0")
+	shutdown, clientTracerProvider, err := Setup(context.Background(), "test-service", "v0.0.0")
 	require.NoError(t, err)
 	require.NotNil(t, shutdown)
+	assert.IsType(t, &sdktrace.TracerProvider{}, clientTracerProvider)
 
 	assert.IsType(t, &sdktrace.TracerProvider{}, otel.GetTracerProvider())
 	assert.IsType(t, &sdkmetric.MeterProvider{}, otel.GetMeterProvider())
@@ -55,6 +57,38 @@ func TestSetup_WithEndpoint(t *testing.T) {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 	_ = shutdown(shutdownCtx)
+}
+
+// TestKubernetesClientTracerProvider asserts the parent-based sampling of the
+// Kubernetes client provider: spans join an existing trace but never start one.
+func TestKubernetesClientTracerProvider(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317")
+	t.Setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "100")
+	t.Cleanup(resetGlobalProviders)
+
+	shutdown, clientTracerProvider, err := Setup(context.Background(), "test-service", "v0.0.0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		_ = shutdown(shutdownCtx)
+	})
+
+	clientTracer := clientTracerProvider.Tracer("test")
+
+	// Without a parent trace, the client span must not be sampled.
+	_, orphan := clientTracer.Start(context.Background(), "orphan")
+	assert.False(t, orphan.SpanContext().IsSampled())
+	orphan.End()
+
+	// Inside a sampled trace, the client span joins it.
+	ctx, parent := otel.Tracer("test").Start(context.Background(), "parent")
+	require.True(t, parent.SpanContext().IsSampled())
+	_, child := clientTracer.Start(ctx, "child")
+	assert.True(t, child.SpanContext().IsSampled())
+	assert.Equal(t, parent.SpanContext().TraceID(), child.SpanContext().TraceID())
+	child.End()
+	parent.End()
 }
 
 // TestHistogramAggregationSelector asserts histograms aggregate as base2 exponential histograms


### PR DESCRIPTION
## Description

This PR completes the storage API server instrumentation for the scan pipeline.

### Traces

* Adds tracing to storage API operations such as `Create`, `Get`, and `GetList`.
* Traces SQL queries as child spans.
* Traces watch events from the storage write through NATS to the consumers.
* Adds the storage server request as part of the existing end-to-end trace.

### Trace propagation

Trace context is propagated from the controller/worker to the storage API server through Kubernetes API calls.

Background Kubernetes traffic, such as probes, discovery, and leader-election requests, is excluded to avoid generating unnecessary traces.

### Metrics

Adds metrics for:

* Storage API request duration by verb, resource, and status code.
* Watch event throughput.
* PostgreSQL operation latency and connection pool metrics through the existing instrumentation libraries.
* Process and Go runtime metrics, including per-replica identification.

### Exemplars

Metrics recorded within sampled traces include trace IDs as exemplars. This allows latency spikes in Prometheus/Grafana to be linked directly to the corresponding trace.

The example dashboard is updated with storage API, PostgreSQL, watch, CPU, and memory metrics.

### RFC

RFC 0009 is updated to document the storage instrumentation, API-call trace propagation, and the general exemplar approach.

> Note: Full OTel chart configuration, including TLS and other options, will be addressed in a follow-up PR.


<img width="1585" height="1185" alt="image" src="https://github.com/user-attachments/assets/717946b8-5f07-4db3-b967-fd7fc0f296cd" />

<img width="1608" height="1170" alt="image" src="https://github.com/user-attachments/assets/3fde888a-57a8-4baa-ba5f-0499e7880e5c" />

