### PR TITLE
fix(worker)!: allow plain-HTTP connections to registries marked as insecure

### DIFF
--- a/examples/private-registry/registry.yaml
+++ b/examples/private-registry/registry.yaml
@@ -5,5 +5,6 @@ metadata:
   namespace: default
 spec:
   uri: dev-registry.default.svc.cluster.local:5000
+  insecure: true
   scanInterval: 1h
   authSecret: my-auth-secret

--- a/examples/registry.yaml
+++ b/examples/registry.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   uri: dev-registry.default.svc.cluster.local:5000
   catalogType: OCIDistribution
+  insecure: true
   scanInterval: 1h
   repositories:
     - name: nginx

--- a/internal/handlers/create_catalog.go
+++ b/internal/handlers/create_catalog.go
@@ -164,7 +164,7 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message messaging.Mes
 	discoveredImageReferences := sets.Set[string]{}
 	for _, repository := range repositories {
 		var repoImages []string
-		repoImages, err = h.discoverImages(ctx, registryClient, repository)
+		repoImages, err = h.discoverImages(ctx, registryClient, registry, repository)
 		if err != nil {
 			return fmt.Errorf("cannot discover images in registry %s: %w", registry.Name, err)
 		}
@@ -195,7 +195,7 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message messaging.Mes
 
 	var discoveredImages []storagev1alpha1.Image
 	for newImageName := range discoveredImageReferences {
-		ref, err := name.ParseReference(newImageName)
+		ref, err := name.ParseReference(newImageName, nameOptions(registry)...)
 		if err != nil {
 			return fmt.Errorf("cannot parse image reference %q: %w", newImageName, err)
 		}
@@ -340,7 +340,7 @@ func (h *CreateCatalogHandler) discoverRepositories(
 	registryClient *registryclient.Client,
 	registry *v1alpha1.Registry,
 ) ([]string, error) {
-	reg, err := name.NewRegistry(registry.Spec.URI)
+	reg, err := name.NewRegistry(registry.Spec.URI, nameOptions(registry)...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse registry %s %s: %w", registry.Name, registry.Namespace, err)
 	}
@@ -370,9 +370,10 @@ func (h *CreateCatalogHandler) discoverRepositories(
 func (h *CreateCatalogHandler) discoverImages(
 	ctx context.Context,
 	registryClient *registryclient.Client,
+	registry *v1alpha1.Registry,
 	repository string,
 ) ([]string, error) {
-	repo, err := name.NewRepository(repository)
+	repo, err := name.NewRepository(repository, nameOptions(registry)...)
 	if err != nil {
 		return []string{}, fmt.Errorf("cannot parse repository name %q: %w", repository, err)
 	}
@@ -570,6 +571,18 @@ func (h *CreateCatalogHandler) transportFromRegistry(registry *v1alpha1.Registry
 	}
 
 	return transport, nil
+}
+
+// nameOptions returns the [name.Option] list to use when parsing references
+// belonging to the given registry. Insecure registries are parsed with
+// [name.Insecure], which allows the transport to fall back to plain HTTP;
+// HTTPS is still attempted first and is unaffected for registries that serve TLS.
+func nameOptions(registry *v1alpha1.Registry) []name.Option {
+	if registry.Spec.Insecure {
+		return []name.Option{name.Insecure}
+	}
+
+	return nil
 }
 
 // deleteObsoleteImages deletes images that are not present in the discovered registry anymore.

--- a/internal/handlers/create_catalog_test.go
+++ b/internal/handlers/create_catalog_test.go
@@ -1074,3 +1074,44 @@ func TestApplyTargetsToRegistry(t *testing.T) {
 		})
 	}
 }
+
+func TestNameOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		insecure   bool
+		wantScheme string
+	}{
+		{
+			name:       "insecure registry allows plain HTTP",
+			insecure:   true,
+			wantScheme: "http",
+		},
+		{
+			name:       "secure registry requires HTTPS",
+			insecure:   false,
+			wantScheme: "https",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := &v1alpha1.Registry{
+				Spec: v1alpha1.RegistrySpec{
+					URI:      "registry.svc.cluster.example:5000",
+					Insecure: test.insecure,
+				},
+			}
+
+			reg, err := name.NewRegistry(registry.Spec.URI, nameOptions(registry)...)
+			require.NoError(t, err)
+			assert.Equal(t, test.wantScheme, reg.Scheme())
+
+			repo, err := name.NewRepository(registry.Spec.URI+"/repo1", nameOptions(registry)...)
+			require.NoError(t, err)
+			assert.Equal(t, test.wantScheme, repo.Registry.Scheme())
+
+			ref, err := name.ParseReference(registry.Spec.URI+"/repo1:latest", nameOptions(registry)...)
+			require.NoError(t, err)
+			assert.Equal(t, test.wantScheme, ref.Context().Registry.Scheme())
+		})
+	}
+}


### PR DESCRIPTION
## Description

go-containerregistry changed how local hostnames are handled, tightening the plain-HTTP heuristic to `*.localhost` only (google/go-containerregistry#2281). This change was released in v0.21.6 and picked up by this repo when bumping from v0.21.5 to v0.21.7.

This ties the Registry's insecure flag to the absence of HTTPS, allowing plain-HTTP connections, as Trivy and Docker do.

This is a breaking change: plain-HTTP registries on `*.local` hostnames must now set `spec.insecure: true`.
