### PR TITLE
feat: integrate db management into sbomscanner

### DIFF
--- a/api/storage/v1alpha1/vulnerabilityreport_types.go
+++ b/api/storage/v1alpha1/vulnerabilityreport_types.go
@@ -152,6 +152,18 @@ type Vulnerability struct {
 
 	// VEXStatus information
 	VEXStatus *VEXStatus `json:"vexStatus,omitempty" protobuf:"bytes,15,opt,name=vexStatus"`
+
+	// KnownExploited is true when the CVE appears in the CISA Known Exploited
+	// Vulnerabilities (KEV) catalog, i.e. it is being actively exploited in the wild.
+	KnownExploited bool `json:"knownExploited,omitempty" protobuf:"varint,17,opt,name=knownExploited"`
+
+	// EPSSScore is the Exploit Prediction Scoring System probability that the CVE
+	// will be exploited (0..1), as a string. Empty when no EPSS data is available.
+	EPSSScore string `json:"epssScore,omitempty" protobuf:"bytes,18,opt,name=epssScore"`
+
+	// EPSSPercentile is the EPSS score's percentile rank (0..1), as a string.
+	// Empty when no EPSS data is available.
+	EPSSPercentile string `json:"epssPercentile,omitempty" protobuf:"bytes,19,opt,name=epssPercentile"`
 }
 
 func (v *VulnerabilityReport) GetImageMetadata() ImageMetadata {

--- a/cmd/sbomscannerdb/cli.go
+++ b/cmd/sbomscannerdb/cli.go
@@ -112,13 +112,20 @@ func pushCommand() *cli.Command {
 func pullCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "pull",
-		Usage:     "Pull the artifact from a registry and write the KEV/EPSS data files to the current directory",
+		Usage:     "Pull the artifact from a registry and write the KEV/EPSS data files to a directory",
 		ArgsUsage: refArgsUsage,
 		Arguments: referenceArguments(),
-		Flags:     registryFlags(),
+		Flags: append(registryFlags(),
+			&cli.StringFlag{
+				Name:    "output-dir",
+				Aliases: []string{"o"},
+				Usage:   "directory to write the KEV/EPSS data files into",
+				Value:   ".",
+			},
+		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			ref := cmd.StringArgs("reference")[0]
-			if err := runPull(ctx, ref, registryConfig(cmd), newLogger(cmd)); err != nil {
+			if err := runPull(ctx, ref, cmd.String("output-dir"), registryConfig(cmd), newLogger(cmd)); err != nil {
 				return cli.Exit("error: "+err.Error(), 1)
 			}
 			return nil

--- a/cmd/sbomscannerdb/commands.go
+++ b/cmd/sbomscannerdb/commands.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"text/tabwriter"
 	"time"
 
@@ -86,14 +88,53 @@ func runPush(ctx context.Context, ref string, config oci.Config, logger *slog.Lo
 	return nil
 }
 
-// runPull fetches the artifact and writes its data files to the current directory.
-func runPull(ctx context.Context, ref string, config oci.Config, logger *slog.Logger) error {
-	paths, err := oci.NewRemote(config, logger).Pull(ctx, ref, ".")
+// runPull fetches the artifact into a temporary directory (so its internal
+// content-addressable cache is discarded) and copies the data files into outputDir.
+func runPull(ctx context.Context, ref, outputDir string, config oci.Config, logger *slog.Logger) error {
+	if err := os.MkdirAll(outputDir, 0o750); err != nil {
+		return fmt.Errorf("create output dir %s: %w", outputDir, err)
+	}
+
+	tempDir, err := os.MkdirTemp("", "sbomscannerdb-pull-*")
+	if err != nil {
+		return fmt.Errorf("create temp pull dir: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	paths, err := oci.NewRemote(config, logger).Pull(ctx, ref, tempDir)
 	if err != nil {
 		return fmt.Errorf("pull artifact: %w", err)
 	}
-	for _, dst := range paths {
+
+	for _, src := range paths {
+		dst := filepath.Join(outputDir, filepath.Base(src))
+		if err := copyFile(src, dst); err != nil {
+			return fmt.Errorf("write %s: %w", dst, err)
+		}
 		fmt.Fprintf(os.Stdout, "pulled %s from %s\n", dst, ref)
+	}
+	return nil
+}
+
+// copyFile copies the regular file at src to dst, truncating dst if it exists.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", src, err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy %s to %s: %w", src, dst, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", dst, err)
 	}
 	return nil
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -17,9 +17,11 @@ import (
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
 	"github.com/kubewarden/sbomscanner/api/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/cmdutil"
+	"github.com/kubewarden/sbomscanner/internal/enrichment"
 	"github.com/kubewarden/sbomscanner/internal/handlers"
 	"github.com/kubewarden/sbomscanner/internal/handlers/registry"
 	"github.com/kubewarden/sbomscanner/internal/messaging"
+	"github.com/kubewarden/sbomscanner/internal/sbomscannerdb/oci"
 	"github.com/kubewarden/sbomscanner/pkg/generated/clientset/versioned/scheme"
 	"github.com/nats-io/nats.go"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
@@ -40,6 +42,10 @@ func main() {
 	var trivyDBRepository string
 	var trivyJavaDBRepository string
 	var installationNamespace string
+	var enrichmentDBRepository string
+	var enrichmentDBCacheDir string
+	var enrichmentDBSkipTLS bool
+	var enrichmentDBPlainHTTP bool
 	var init bool
 	var logLevel string
 	var mode string
@@ -53,6 +59,10 @@ func main() {
 	flag.StringVar(&trivyDBRepository, "trivy-db-repository", "public.ecr.aws/aquasecurity/trivy-db", "OCI repository to retrieve trivy-db.")
 	flag.StringVar(&trivyJavaDBRepository, "trivy-java-db-repository", "public.ecr.aws/aquasecurity/trivy-java-db", "OCI repository to retrieve trivy-java-db.")
 	flag.StringVar(&installationNamespace, "installation-namespace", "sbomscanner", "The namespace where sbomscanner is installed.")
+	flag.StringVar(&enrichmentDBRepository, "enrichment-db-repository", "", "OCI reference (tag) of the enrichment vulnerability database (KEV, EPSS, …). Empty disables enrichment.")
+	flag.StringVar(&enrichmentDBCacheDir, "enrichment-db-cache-dir", "", "Directory to store the local enrichment database cache (defaults to <run-dir>/enrichment).")
+	flag.BoolVar(&enrichmentDBSkipTLS, "enrichment-db-skip-tls-verify", false, "Skip TLS verification when pulling the enrichment database.")
+	flag.BoolVar(&enrichmentDBPlainHTTP, "enrichment-db-plain-http", false, "Use plain HTTP when pulling the enrichment database.")
 	flag.BoolVar(&init, "init", false, "Run initialization tasks and exit.")
 	flag.StringVar(&logLevel, "log-level", slog.LevelInfo.String(), "Log level.")
 	flag.StringVar(&mode, "mode", "registry", "Mode of operation ('registry' or 'node').")
@@ -148,6 +158,14 @@ func main() {
 		return registry.NewClient(transport, logger)
 	}
 
+	enrichment.CleanCache(runDir, logger)
+
+	enrichmentStore := setupEnrichmentStore(ctx, enrichmentDBRepository, enrichmentDBCacheDir, runDir, oci.Config{
+		SkipTLSVerify:  enrichmentDBSkipTLS,
+		PlainHTTP:      enrichmentDBPlainHTTP,
+		AllowAnonymous: true,
+	}, logger)
+
 	var scanMode messaging.HandlerRegistry
 	durableName := "worker"
 	switch mode {
@@ -155,12 +173,12 @@ func main() {
 		scanMode = messaging.HandlerRegistry{
 			handlers.CreateCatalogSubject: handlers.NewCreateCatalogHandler(registryClientFactory, k8sClient, scheme, publisher, installationNamespace, logger),
 			handlers.GenerateSBOMSubject:  handlers.NewGenerateSBOMHandler(k8sClient, scheme, runDir, trivyJavaDBRepository, publisher, installationNamespace, logger),
-			handlers.ScanSBOMSubject:      handlers.NewScanSBOMHandler(k8sClient, scheme, runDir, trivyDBRepository, trivyJavaDBRepository, logger),
+			handlers.ScanSBOMSubject:      handlers.NewScanSBOMHandler(k8sClient, scheme, runDir, trivyDBRepository, trivyJavaDBRepository, enrichmentStore, logger),
 		}
 	case nodeMode:
 		scanMode = messaging.HandlerRegistry{
 			handlers.GenerateNodeSBOMSubject + "." + nodeName: handlers.NewGenerateNodeSBOMHandler(k8sClient, scheme, runDir, targetDir, trivyJavaDBRepository, publisher, installationNamespace, logger),
-			handlers.ScanNodeSBOMSubject + "." + nodeName:     handlers.NewNodeScanSBOMHandler(k8sClient, scheme, runDir, trivyDBRepository, trivyJavaDBRepository, logger),
+			handlers.ScanNodeSBOMSubject + "." + nodeName:     handlers.NewNodeScanSBOMHandler(k8sClient, scheme, runDir, trivyDBRepository, trivyJavaDBRepository, enrichmentStore, logger),
 		}
 		durableName = "worker-node-" + nodeName
 	default:
@@ -200,6 +218,26 @@ func main() {
 		logger.Error("Error shutting down health check server", "error", err)
 		os.Exit(1)
 	}
+}
+
+// setupEnrichmentStore builds the enrichment DB store and performs an initial,
+// best-effort refresh. When no repository is configured the feature is disabled and
+// a nil store is returned (handlers treat nil as "no enrichment"). A failed initial
+// pull never blocks startup: scans simply produce unenriched reports until the next
+// successful refresh.
+func setupEnrichmentStore(ctx context.Context, repository, cacheDir, runDir string, cfg oci.Config, logger *slog.Logger) *enrichment.Store {
+	if repository == "" {
+		logger.InfoContext(ctx, "Enrichment database disabled (no repository configured)")
+		return nil
+	}
+	if cacheDir == "" {
+		cacheDir = enrichment.DefaultCacheDir(runDir)
+	}
+
+	store := enrichment.New(repository, cacheDir, cfg, logger)
+	logger.InfoContext(ctx, "Performing initial enrichment database pull", "repository", repository, "cacheDir", cacheDir)
+	store.Update(ctx)
+	return store
 }
 
 func runHealthServer(logger *slog.Logger) *http.Server {

--- a/docs/crds/CRD-docs-for-docs-repo.adoc
+++ b/docs/crds/CRD-docs-for-docs-repo.adoc
@@ -1250,6 +1250,12 @@ May be empty when the source vendor is not known. + |  |
 | *`suppressed`* __boolean__ | Suppressed identify when vulnerability has +
 been suppressed by VEX documents + |  | 
 | *`vexStatus`* __xref:{anchor_prefix}-github-com-kubewarden-sbomscanner-api-storage-v1alpha1-vexstatus[$$VEXStatus$$]__ | VEXStatus information + |  | 
+| *`knownExploited`* __boolean__ | KnownExploited is true when the CVE appears in the CISA Known Exploited +
+Vulnerabilities (KEV) catalog, i.e. it is being actively exploited in the wild. + |  | 
+| *`epssScore`* __string__ | EPSSScore is the Exploit Prediction Scoring System probability that the CVE +
+will be exploited (0..1), as a string. Empty when no EPSS data is available. + |  | 
+| *`epssPercentile`* __string__ | EPSSPercentile is the EPSS score's percentile rank (0..1), as a string. +
+Empty when no EPSS data is available. + |  | 
 |===
 
 

--- a/docs/crds/CRD-docs-for-docs-repo.md
+++ b/docs/crds/CRD-docs-for-docs-repo.md
@@ -944,6 +944,9 @@ _Appears in:_
 | `cwes` _string array_ | CWEs with which the CVE is classified |  |  |
 | `suppressed` _boolean_ | Suppressed identify when vulnerability has<br />been suppressed by VEX documents |  |  |
 | `vexStatus` _[VEXStatus](#vexstatus)_ | VEXStatus information |  |  |
+| `knownExploited` _boolean_ | KnownExploited is true when the CVE appears in the CISA Known Exploited<br />Vulnerabilities (KEV) catalog, i.e. it is being actively exploited in the wild. |  |  |
+| `epssScore` _string_ | EPSSScore is the Exploit Prediction Scoring System probability that the CVE<br />will be exploited (0..1), as a string. Empty when no EPSS data is available. |  |  |
+| `epssPercentile` _string_ | EPSSPercentile is the EPSS score's percentile rank (0..1), as a string.<br />Empty when no EPSS data is available. |  |  |
 
 
 #### VulnerabilityReport

--- a/internal/enrichment/doc.go
+++ b/internal/enrichment/doc.go
@@ -1,0 +1,6 @@
+// Package enrichment consumes the sbomscanner enrichment vulnerability database
+// (an OCI artifact carrying KEV, EPSS, … feeds) and serves per-CVE lookups from a
+// local cache. It reuses the OCI pull/inspect primitives and feed parsers from the
+// internal/sbomscannerdb packages; the enrichment data is optional, so a missing or
+// stale cache degrades gracefully to unenriched lookups rather than blocking scans.
+package enrichment

--- a/internal/enrichment/store.go
+++ b/internal/enrichment/store.go
@@ -1,0 +1,277 @@
+package enrichment
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/kubewarden/sbomscanner/internal/sbomscannerdb/datafeed"
+	"github.com/kubewarden/sbomscanner/internal/sbomscannerdb/oci"
+)
+
+// nextUpdateFileName is the file in the cache dir where the last pulled artifact's
+// nextUpdate annotation is persisted, so the common-case freshness check needs no
+// registry contact at all.
+const nextUpdateFileName = "nextUpdate"
+
+// cacheDirName is the enrichment cache subdirectory under the worker run dir.
+const cacheDirName = "enrichment"
+
+// DefaultCacheDir returns the enrichment cache directory nested under runDir.
+func DefaultCacheDir(runDir string) string {
+	return filepath.Join(runDir, cacheDirName)
+}
+
+// CleanCache removes any enrichment cache left over from a previous run. When the
+// worker's run directory is backed by a persistent volume, files such as the
+// persisted nextUpdate horizon survive a pod restart and can make the store
+// believe its cache is still fresh. Wiping the directory on startup forces a
+// clean pull. A missing directory is not an error.
+func CleanCache(runDir string, logger *slog.Logger) {
+	dir := DefaultCacheDir(runDir)
+	if err := os.RemoveAll(dir); err != nil {
+		logger.Warn("Failed to clean up stale enrichment cache", "dir", dir, "error", err)
+		return
+	}
+	logger.Info("Cleaned up stale enrichment cache", "dir", dir)
+}
+
+// Enrichment is the auxiliary context looked up for a single CVE.
+// The zero value means "no enrichment data" (unknown CVE or no cache).
+type Enrichment struct {
+	// KnownExploited is true when the CVE is in the CISA KEV catalog.
+	KnownExploited bool
+	// EPSSScore is the exploit-probability score; valid only when EPSSFound.
+	EPSSScore float64
+	// EPSSPercentile is the score's percentile; valid only when EPSSFound.
+	EPSSPercentile float64
+	// EPSSFound reports whether the CVE had an EPSS row.
+	EPSSFound bool
+}
+
+// Store owns the local enrichment cache: it pulls the DB artifact lazily, unpacks it,
+// and holds in-memory indices keyed by CVE ID for cheap lookups during scans.
+// A nil *Store is a valid no-op (feature disabled) and returns empty enrichments.
+type Store struct {
+	ref      string
+	cacheDir string
+	remote   *oci.Remote
+	logger   *slog.Logger
+
+	mu   sync.RWMutex
+	kev  map[string]struct{}
+	epss map[string]datafeed.EPSSScore
+	// nextUpdate is the freshness horizon of the currently loaded cache; while
+	// now < nextUpdate the store serves from memory without touching the registry.
+	nextUpdate time.Time
+	loaded     bool
+}
+
+// New returns a Store that pulls the artifact at ref into cacheDir.
+// It does not contact the registry; call Refresh to populate the cache.
+func New(ref, cacheDir string, cfg oci.Config, logger *slog.Logger) *Store {
+	return &Store{
+		ref:      ref,
+		cacheDir: cacheDir,
+		remote:   oci.NewRemote(cfg, logger),
+		logger:   logger,
+		kev:      map[string]struct{}{},
+		epss:     map[string]datafeed.EPSSScore{},
+	}
+}
+
+// Update ensures the local cache is reasonably fresh, contacting the registry only
+// when the persisted nextUpdate horizon has passed. A registry failure is never
+// fatal: the store keeps serving whatever it already has (possibly nothing) and the
+// error is logged, so scans continue with stale-or-absent enrichment data.
+func (s *Store) Update(ctx context.Context) {
+	if s == nil {
+		return
+	}
+
+	// On first Update, adopt any cache left on disk from a previous run so a
+	// registry outage at startup still yields enrichment data.
+	if !s.loaded {
+		s.bootstrapFromDisk(ctx)
+	}
+
+	// If the current time is before the freshness horizon, no update is needed.
+	if time.Now().Before(s.horizon()) {
+		return
+	}
+
+	view, err := s.remote.Inspect(ctx, s.ref)
+	if err != nil {
+		s.logger.WarnContext(ctx, "enrichment DB inspect failed, serving existing cache", "ref", s.ref, "error", err)
+		return
+	}
+
+	remoteNext, err := parseNextUpdate(view.Annotations[oci.AnnotationNextUpdate])
+	if err != nil {
+		s.logger.WarnContext(ctx, "enrichment DB has no usable nextUpdate annotation, pulling anyway", "ref", s.ref, "error", err)
+	} else if s.loaded && !remoteNext.After(s.horizon()) {
+		// Registry has nothing newer than what we already serve; refresh the horizon
+		// so we don't re-inspect on every scan until the next window.
+		s.setHorizon(remoteNext)
+		return
+	}
+
+	if err := os.MkdirAll(s.cacheDir, 0o750); err != nil {
+		s.logger.WarnContext(ctx, "failed to create enrichment cache dir, serving existing cache", "dir", s.cacheDir, "error", err)
+		return
+	}
+	if _, err := s.remote.Pull(ctx, s.ref, s.cacheDir); err != nil {
+		s.logger.WarnContext(ctx, "enrichment DB pull failed, serving existing cache", "ref", s.ref, "error", err)
+		return
+	}
+
+	if err := s.load(ctx); err != nil {
+		s.logger.WarnContext(ctx, "failed to load pulled enrichment DB, serving existing cache", "error", err)
+		return
+	}
+	s.setHorizon(remoteNext)
+	s.persistNextUpdate(ctx, remoteNext)
+	s.logger.InfoContext(ctx, "enrichment DB refreshed", "ref", s.ref, "kev", len(s.kev), "epss", len(s.epss), "nextUpdate", remoteNext)
+}
+
+// Lookup returns the enrichment for cve, or a zero Enrichment when the CVE is absent
+// or no cache is loaded.
+func (s *Store) Lookup(cve string) Enrichment {
+	if s == nil {
+		return Enrichment{}
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var e Enrichment
+	if _, ok := s.kev[cve]; ok {
+		e.KnownExploited = true
+	}
+	if score, ok := s.epss[cve]; ok {
+		e.EPSSScore = score.EPSS
+		e.EPSSPercentile = score.Percentile
+		e.EPSSFound = true
+	}
+	return e
+}
+
+// bootstrapFromDisk loads a cache directory that already holds feed files (e.g. left
+// by a prior run) and its persisted nextUpdate, so the store is usable before any
+// successful registry contact.
+func (s *Store) bootstrapFromDisk(ctx context.Context) {
+	if err := s.load(ctx); err != nil {
+		// No usable on-disk cache yet; that's expected on a truly first run.
+		s.logger.DebugContext(ctx, "no existing enrichment cache to bootstrap", "dir", s.cacheDir, "error", err)
+		return
+	}
+	if next, err := readNextUpdate(s.cacheDir); err == nil {
+		s.setHorizon(next)
+	}
+	s.logger.InfoContext(ctx, "bootstrapped enrichment DB from disk cache", "kev", len(s.kev), "epss", len(s.epss))
+}
+
+// load parses the KEV and EPSS files from the cache dir and swaps in fresh indices.
+// It fails only when neither feed can be read; a single missing/unparseable feed is
+// tolerated so the other still enriches.
+func (s *Store) load(ctx context.Context) error {
+	kev, kevErr := loadKEV(filepath.Join(s.cacheDir, datafeed.KEVFileName))
+	if kevErr != nil {
+		s.logger.DebugContext(ctx, "KEV feed unavailable", "error", kevErr)
+	}
+	epss, epssErr := loadEPSS(filepath.Join(s.cacheDir, datafeed.EPSSFileName))
+	if epssErr != nil {
+		s.logger.DebugContext(ctx, "EPSS feed unavailable", "error", epssErr)
+	}
+	if kevErr != nil && epssErr != nil {
+		return errors.New("no enrichment feeds could be loaded")
+	}
+
+	s.mu.Lock()
+	s.kev = kev
+	s.epss = epss
+	s.loaded = true
+	s.mu.Unlock()
+	return nil
+}
+
+func loadKEV(path string) (map[string]struct{}, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return map[string]struct{}{}, fmt.Errorf("open KEV catalog %s: %w", path, err)
+	}
+	defer file.Close()
+
+	catalog, err := datafeed.ParseKEVCatalog(file)
+	if err != nil {
+		return map[string]struct{}{}, fmt.Errorf("parse KEV catalog %s: %w", path, err)
+	}
+	index := make(map[string]struct{}, len(catalog.Vulnerabilities))
+	for _, vuln := range catalog.Vulnerabilities {
+		index[vuln.CVEID] = struct{}{}
+	}
+	return index, nil
+}
+
+func loadEPSS(path string) (map[string]datafeed.EPSSScore, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return map[string]datafeed.EPSSScore{}, fmt.Errorf("open EPSS scores %s: %w", path, err)
+	}
+	defer file.Close()
+
+	scores, err := datafeed.ParseEPSSScores(file)
+	if err != nil {
+		return map[string]datafeed.EPSSScore{}, fmt.Errorf("parse EPSS scores %s: %w", path, err)
+	}
+	index := make(map[string]datafeed.EPSSScore, len(scores.Scores))
+	for _, score := range scores.Scores {
+		index[score.CVE] = score
+	}
+	return index, nil
+}
+
+func (s *Store) horizon() time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.nextUpdate
+}
+
+func (s *Store) setHorizon(t time.Time) {
+	s.mu.Lock()
+	s.nextUpdate = t
+	s.mu.Unlock()
+}
+
+func (s *Store) persistNextUpdate(ctx context.Context, t time.Time) {
+	if t.IsZero() {
+		return
+	}
+	path := filepath.Join(s.cacheDir, nextUpdateFileName)
+	if err := os.WriteFile(path, []byte(t.UTC().Format(time.RFC3339)), 0o600); err != nil {
+		s.logger.WarnContext(ctx, "failed to persist enrichment nextUpdate", "path", path, "error", err)
+	}
+}
+
+func readNextUpdate(cacheDir string) (time.Time, error) {
+	data, err := os.ReadFile(filepath.Join(cacheDir, nextUpdateFileName))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("read nextUpdate file: %w", err)
+	}
+	return parseNextUpdate(string(data))
+}
+
+func parseNextUpdate(value string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, errors.New("empty nextUpdate")
+	}
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse nextUpdate %q: %w", value, err)
+	}
+	return t, nil
+}

--- a/internal/enrichment/store_test.go
+++ b/internal/enrichment/store_test.go
@@ -1,0 +1,152 @@
+package enrichment
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kubewarden/sbomscanner/internal/sbomscannerdb/datafeed"
+	"github.com/kubewarden/sbomscanner/internal/sbomscannerdb/oci"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testKEV = `{
+  "title": "CISA KEV",
+  "catalogVersion": "2026.07.16",
+  "count": 2,
+  "vulnerabilities": [
+    {"cveID": "CVE-2021-44228"},
+    {"cveID": "CVE-2019-0708"}
+  ]
+}`
+	testEPSS = `#model_version:v2026.07.16,score_date:2026-07-16T00:00:00Z
+cve,epss,percentile
+CVE-2021-44228,0.97,0.999
+CVE-2020-1234,0.01,0.5
+`
+)
+
+// seedCache writes the KEV and EPSS feed files into dir.
+func seedCache(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.KEVFileName), []byte(testKEV), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.EPSSFileName), []byte(testEPSS), 0o600))
+}
+
+func newTestStore(cacheDir string) *Store {
+	return New("registry.example.com/db:latest", cacheDir, oci.Config{}, slog.New(slog.DiscardHandler))
+}
+
+func TestLookup_AfterLoad(t *testing.T) {
+	dir := t.TempDir()
+	seedCache(t, dir)
+	store := newTestStore(dir)
+	require.NoError(t, store.load(context.Background()))
+
+	tests := []struct {
+		name string
+		cve  string
+		want Enrichment
+	}{
+		{
+			name: "KEV and EPSS",
+			cve:  "CVE-2021-44228",
+			want: Enrichment{KnownExploited: true, EPSSScore: 0.97, EPSSPercentile: 0.999, EPSSFound: true},
+		},
+		{
+			name: "KEV only",
+			cve:  "CVE-2019-0708",
+			want: Enrichment{KnownExploited: true},
+		},
+		{
+			name: "EPSS only",
+			cve:  "CVE-2020-1234",
+			want: Enrichment{EPSSScore: 0.01, EPSSPercentile: 0.5, EPSSFound: true},
+		},
+		{
+			name: "unknown CVE",
+			cve:  "CVE-0000-0000",
+			want: Enrichment{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, store.Lookup(tc.cve))
+		})
+	}
+}
+
+func TestLookup_NilStoreIsNoOp(t *testing.T) {
+	var store *Store
+	assert.Equal(t, Enrichment{}, store.Lookup("CVE-2021-44228"))
+	store.Update(context.Background()) // must not panic
+}
+
+func TestRefresh_BootstrapsFromDiskAndStaysFreshWhileWithinHorizon(t *testing.T) {
+	dir := t.TempDir()
+	seedCache(t, dir)
+	// Persist a nextUpdate far in the future so Refresh serves the disk cache
+	// without ever contacting the (unreachable) registry.
+	future := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, nextUpdateFileName), []byte(future), 0o600))
+
+	store := newTestStore(dir)
+	store.Update(context.Background())
+
+	// Loaded from disk, and lookups work despite the registry being unreachable.
+	assert.True(t, store.Lookup("CVE-2021-44228").KnownExploited)
+	assert.True(t, store.loaded)
+}
+
+func TestRefresh_RegistryFailureDegradesGracefully(t *testing.T) {
+	dir := t.TempDir() // empty: no cache, no persisted horizon
+	store := newTestStore(dir)
+
+	// Horizon is zero, so Refresh will try the (unreachable) registry and fail,
+	// but it must not panic and must leave the store usable-but-empty.
+	store.Update(context.Background())
+
+	assert.Equal(t, Enrichment{}, store.Lookup("CVE-2021-44228"))
+}
+
+func TestLoad_ToleratesSingleMissingFeed(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.KEVFileName), []byte(testKEV), 0o600))
+	// No EPSS file.
+	store := newTestStore(dir)
+	require.NoError(t, store.load(context.Background()))
+
+	assert.True(t, store.Lookup("CVE-2021-44228").KnownExploited)
+	assert.False(t, store.Lookup("CVE-2021-44228").EPSSFound)
+}
+
+func TestLoad_FailsWhenNoFeeds(t *testing.T) {
+	store := newTestStore(t.TempDir())
+	require.Error(t, store.load(context.Background()))
+}
+
+func TestCleanCache_RemovesStaleCache(t *testing.T) {
+	runDir := t.TempDir()
+	cacheDir := DefaultCacheDir(runDir)
+	require.NoError(t, os.MkdirAll(cacheDir, 0o700))
+	// A leftover nextUpdate is exactly what makes a restarted store skip the pull.
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, nextUpdateFileName), []byte("2999-01-01T00:00:00Z"), 0o600))
+
+	CleanCache(runDir, slog.New(slog.DiscardHandler))
+
+	_, err := os.Stat(cacheDir)
+	assert.True(t, os.IsNotExist(err), "enrichment cache dir must be removed")
+}
+
+func TestCleanCache_NoDirIsNoOp(t *testing.T) {
+	runDir := t.TempDir() // no enrichment subdir exists
+	// Must not panic or fail when there is nothing to clean.
+	CleanCache(runDir, slog.New(slog.DiscardHandler))
+	_, err := os.Stat(DefaultCacheDir(runDir))
+	assert.True(t, os.IsNotExist(err))
+}

--- a/internal/handlers/node_scan_sbom.go
+++ b/internal/handlers/node_scan_sbom.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubewarden/sbomscanner/api"
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
 	"github.com/kubewarden/sbomscanner/api/v1alpha1"
+	"github.com/kubewarden/sbomscanner/internal/enrichment"
 	"github.com/kubewarden/sbomscanner/internal/messaging"
 )
 
@@ -32,6 +33,7 @@ func NewNodeScanSBOMHandler(
 	workDir string,
 	trivyDBRepository string,
 	trivyJavaDBRepository string,
+	enrichmentStore *enrichment.Store,
 	logger *slog.Logger,
 ) *NodeScanSBOMHandler {
 	return &NodeScanSBOMHandler{
@@ -41,6 +43,7 @@ func NewNodeScanSBOMHandler(
 			workDir:               workDir,
 			trivyDBRepository:     trivyDBRepository,
 			trivyJavaDBRepository: trivyJavaDBRepository,
+			enrichmentStore:       enrichmentStore,
 			logger:                logger.With("handler", "scan_node_sbom_handler"),
 		},
 	}

--- a/internal/handlers/node_scan_sbom_test.go
+++ b/internal/handlers/node_scan_sbom_test.go
@@ -64,7 +64,7 @@ func TestNodeScanSBOMHandler_Handle(t *testing.T) {
 		WithStatusSubresource(&v1alpha1.NodeScanJob{}).
 		Build()
 
-	handler := NewNodeScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
+	handler := NewNodeScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, nil, slog.Default())
 
 	message, err := json.Marshal(&ScanNodeSBOMMessage{
 		NodeBaseMessage: NodeBaseMessage{
@@ -174,7 +174,7 @@ func TestNodeScanSBOMHandler_Handle_StopProcessing(t *testing.T) {
 				Build()
 
 			cacheDir := t.TempDir()
-			handler := NewNodeScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
+			handler := NewNodeScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, nil, slog.Default())
 
 			message, err := json.Marshal(&ScanNodeSBOMMessage{
 				NodeBaseMessage: NodeBaseMessage{

--- a/internal/handlers/scan_sbom.go
+++ b/internal/handlers/scan_sbom.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubewarden/sbomscanner/api"
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
 	"github.com/kubewarden/sbomscanner/api/v1alpha1"
+	"github.com/kubewarden/sbomscanner/internal/enrichment"
 	"github.com/kubewarden/sbomscanner/internal/messaging"
 )
 
@@ -31,6 +32,7 @@ func NewScanSBOMHandler(
 	workDir string,
 	trivyDBRepository string,
 	trivyJavaDBRepository string,
+	enrichmentStore *enrichment.Store,
 	logger *slog.Logger,
 ) *ScanSBOMHandler {
 	return &ScanSBOMHandler{
@@ -40,6 +42,7 @@ func NewScanSBOMHandler(
 			workDir:               workDir,
 			trivyDBRepository:     trivyDBRepository,
 			trivyJavaDBRepository: trivyJavaDBRepository,
+			enrichmentStore:       enrichmentStore,
 			logger:                logger.With("handler", "scan_sbom_handler"),
 		},
 	}

--- a/internal/handlers/scan_sbom_helpers.go
+++ b/internal/handlers/scan_sbom_helpers.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path"
+	"strconv"
 
 	"go.yaml.in/yaml/v3"
 	_ "modernc.org/sqlite" // sqlite driver for RPM DB and Java DB
@@ -21,6 +22,7 @@ import (
 	trivyTypes "github.com/aquasecurity/trivy/pkg/types"
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
 	"github.com/kubewarden/sbomscanner/api/v1alpha1"
+	"github.com/kubewarden/sbomscanner/internal/enrichment"
 	trivyreport "github.com/kubewarden/sbomscanner/internal/handlers/trivyreport"
 	"github.com/kubewarden/sbomscanner/internal/messaging"
 )
@@ -37,6 +39,7 @@ type scanSBOMBase struct {
 	workDir               string
 	trivyDBRepository     string
 	trivyJavaDBRepository string
+	enrichmentStore       *enrichment.Store
 	logger                *slog.Logger
 }
 
@@ -147,9 +150,34 @@ func (b *scanSBOMBase) runTrivyScan(ctx context.Context, rawSPDX []byte, message
 		return nil, storagev1alpha1.Summary{}, fmt.Errorf("failed to convert from trivy results: %w", err)
 	}
 
+	b.enrichResults(ctx, results)
+
 	summary := storagev1alpha1.NewSummaryFromResults(results)
 
 	return results, summary, nil
+}
+
+// enrichResults augments each vulnerability with auxiliary context (KEV, EPSS) from
+// the local enrichment database. Enrichment is best-effort and optional: a nil store
+// or a stale/absent cache simply leaves the extra fields empty and never fails a scan.
+func (b *scanSBOMBase) enrichResults(ctx context.Context, results []storagev1alpha1.Result) {
+	if b.enrichmentStore == nil {
+		return
+	}
+	b.enrichmentStore.Update(ctx)
+
+	for i := range results {
+		vulns := results[i].Vulnerabilities
+		for j := range vulns {
+			vuln := &vulns[j]
+			data := b.enrichmentStore.Lookup(vuln.CVE)
+			vuln.KnownExploited = data.KnownExploited
+			if data.EPSSFound {
+				vuln.EPSSScore = strconv.FormatFloat(data.EPSSScore, 'f', -1, 64)
+				vuln.EPSSPercentile = strconv.FormatFloat(data.EPSSPercentile, 'f', -1, 64)
+			}
+		}
+	}
 }
 
 // setupVEXHubRepositories creates the VEX repository configuration file for trivy based on the provided VEXHubList.

--- a/internal/handlers/scan_sbom_helpers_test.go
+++ b/internal/handlers/scan_sbom_helpers_test.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
+	"github.com/kubewarden/sbomscanner/internal/enrichment"
+	"github.com/kubewarden/sbomscanner/internal/sbomscannerdb/datafeed"
+	"github.com/kubewarden/sbomscanner/internal/sbomscannerdb/oci"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	enrichTestKEV = `{"title":"KEV","count":1,"vulnerabilities":[{"cveID":"CVE-2021-44228"}]}`
+	//nolint:lll // csv fixture
+	enrichTestEPSS = "#model_version:v1,score_date:2026-07-16T00:00:00Z\ncve,epss,percentile\nCVE-2021-44228,0.97,0.999\n"
+)
+
+func seededEnrichmentStore(t *testing.T) *enrichment.Store {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.KEVFileName), []byte(enrichTestKEV), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.EPSSFileName), []byte(enrichTestEPSS), 0o600))
+	// A far-future persisted horizon keeps Refresh from contacting any registry.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "nextUpdate"), []byte("2999-01-01T00:00:00Z"), 0o600))
+	return enrichment.New("registry.example.com/db:latest", dir, oci.Config{}, slog.New(slog.DiscardHandler))
+}
+
+func TestEnrichResults_PopulatesKEVAndEPSS(t *testing.T) {
+	base := &scanSBOMBase{
+		enrichmentStore: seededEnrichmentStore(t),
+		logger:          slog.New(slog.DiscardHandler),
+	}
+	results := []storagev1alpha1.Result{
+		{Vulnerabilities: []storagev1alpha1.Vulnerability{
+			{CVE: "CVE-2021-44228"},
+			{CVE: "CVE-0000-0000"},
+		}},
+	}
+
+	base.enrichResults(context.Background(), results)
+
+	exploited := results[0].Vulnerabilities[0]
+	assert.True(t, exploited.KnownExploited)
+	assert.Equal(t, "0.97", exploited.EPSSScore)
+	assert.Equal(t, "0.999", exploited.EPSSPercentile)
+
+	unknown := results[0].Vulnerabilities[1]
+	assert.False(t, unknown.KnownExploited)
+	assert.Empty(t, unknown.EPSSScore)
+	assert.Empty(t, unknown.EPSSPercentile)
+}
+
+func TestEnrichResults_NilStoreLeavesResultsUnchanged(t *testing.T) {
+	base := &scanSBOMBase{logger: slog.New(slog.DiscardHandler)}
+	results := []storagev1alpha1.Result{
+		{Vulnerabilities: []storagev1alpha1.Vulnerability{{CVE: "CVE-2021-44228"}}},
+	}
+
+	base.enrichResults(context.Background(), results)
+
+	assert.False(t, results[0].Vulnerabilities[0].KnownExploited)
+	assert.Empty(t, results[0].Vulnerabilities[0].EPSSScore)
+}

--- a/internal/handlers/scan_sbom_test.go
+++ b/internal/handlers/scan_sbom_test.go
@@ -182,7 +182,7 @@ func testScanSBOM(t *testing.T, cacheDir, platform, sourceSBOMJSON, expectedRepo
 	err = json.Unmarshal(reportData, expectedReport)
 	require.NoError(t, err, "failed to unmarshal expected report file %s", expectedReportJSON)
 
-	handler := NewScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
+	handler := NewScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, nil, slog.Default())
 
 	message, err := json.Marshal(&ScanSBOMMessage{
 		BaseMessage: BaseMessage{
@@ -320,7 +320,7 @@ func TestScanSBOMHandler_Handle_StopProcessing(t *testing.T) {
 				Build()
 
 			cacheDir := t.TempDir()
-			handler := NewScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, slog.Default())
+			handler := NewScanSBOMHandler(k8sClient, scheme, cacheDir, testTrivyDBRepository, testTrivyJavaDBRepository, nil, slog.Default())
 
 			message, err := json.Marshal(&ScanSBOMMessage{
 				BaseMessage: BaseMessage{

--- a/internal/sbomscannerdb/oci/remote.go
+++ b/internal/sbomscannerdb/oci/remote.go
@@ -14,10 +14,13 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	oras "oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	orasoci "oras.land/oras-go/v2/content/oci"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry"
 	orasremote "oras.land/oras-go/v2/registry/remote"
@@ -34,6 +37,10 @@ type Config struct {
 	SkipTLSVerify bool
 	// PlainHTTP uses HTTP instead of HTTPS.
 	PlainHTTP bool
+	// AllowAnonymous permits pulls when no docker config.json is present.
+	// When a config.json IS present it is still used, so this makes
+	// credentials optional rather than disabling them.
+	AllowAnonymous bool
 }
 
 // Remote performs push and pull operations against OCI registries.
@@ -97,10 +104,17 @@ func (r *Remote) Push(ctx context.Context, store *Store, ref string) (Artifact, 
 	}, nil
 }
 
-// Pull fetches the DB artifact at the given tag reference,
-// extracts each data layer (a tar.gz), and writes the contained files
-// (e.g. known_exploited_vulnerabilities.json, epss_scores.csv) into outDir.
-// It returns the written file paths in manifest layer order.
+// pullCacheDir is the content-addressable cache subdirectory created inside a
+// pull's outDir. It persists between pulls so oras.Copy downloads each blob once
+// and skips it on subsequent rebuilds whose feed content (and thus blob digest)
+// is unchanged.
+const pullCacheDir = ".store"
+
+// Pull fetches the DB artifact at the given tag reference into a persistent
+// content-addressable cache under outDir (re-downloading only blobs it does not
+// already have), then extracts each data layer (a tar.gz) and writes the
+// contained files (e.g. known_exploited_vulnerabilities.json, epss_scores.csv)
+// into outDir. It returns the written file paths in manifest layer order.
 func (r *Remote) Pull(ctx context.Context, ref, outDir string) ([]string, error) {
 	srcRef, err := parseTagReference(ref)
 	if err != nil {
@@ -112,15 +126,45 @@ func (r *Remote) Pull(ctx context.Context, ref, outDir string) ([]string, error)
 		return nil, err
 	}
 
-	layerDescs, err := r.resolveDataLayers(ctx, repo, srcRef.Reference)
+	store, err := openPullCache(filepath.Join(outDir, pullCacheDir))
+	if err != nil {
+		return nil, err
+	}
+
+	// oras.Copy walks the manifest graph and fetches only blobs the local cache
+	// is missing; unchanged feeds keep their blob digest and are skipped.
+	// PreCopy/OnCopySkipped run concurrently across copy goroutines, so the
+	// counters must be updated atomically.
+	var fetched, skipped atomic.Int64
+	copyOpts := oras.DefaultCopyOptions
+	copyOpts.PreCopy = func(_ context.Context, desc ocispec.Descriptor) error {
+		fetched.Add(1)
+		r.logger.InfoContext(ctx, "fetching blob", "mediaType", desc.MediaType, "digest", desc.Digest, "bytes", desc.Size)
+		return nil
+	}
+	copyOpts.OnCopySkipped = func(_ context.Context, desc ocispec.Descriptor) error {
+		skipped.Add(1)
+		r.logger.DebugContext(ctx, "skipped blob, already cached", "mediaType", desc.MediaType, "digest", desc.Digest)
+		return nil
+	}
+	if _, err := oras.Copy(ctx, repo, srcRef.Reference, store, srcRef.Reference, copyOpts); err != nil {
+		return nil, fmt.Errorf("copy from remote: %w", err)
+	}
+	if fetched.Load() == 0 {
+		r.logger.InfoContext(ctx, "enrichment DB unchanged, served from local cache", "ref", srcRef.String(), "cachedBlobs", skipped.Load())
+	} else {
+		r.logger.InfoContext(ctx, "enrichment DB updated from registry", "ref", srcRef.String(), "fetchedBlobs", fetched.Load(), "cachedBlobs", skipped.Load())
+	}
+
+	layerDescs, err := resolveDataLayers(ctx, store, srcRef.Reference)
 	if err != nil {
 		return nil, err
 	}
 
 	var paths []string
 	for _, layerDesc := range layerDescs {
-		r.logger.InfoContext(ctx, "pulling data layer", "ref", srcRef.String(), "layer", layerDesc.Annotations[ocispec.AnnotationTitle], "digest", layerDesc.Digest, "bytes", layerDesc.Size)
-		extracted, err := fetchAndExtractLayer(ctx, repo, layerDesc, outDir)
+		r.logger.InfoContext(ctx, "extracting data layer", "ref", srcRef.String(), "layer", layerDesc.Annotations[ocispec.AnnotationTitle], "digest", layerDesc.Digest, "bytes", layerDesc.Size)
+		extracted, err := fetchAndExtractLayer(ctx, store, layerDesc, outDir)
 		if err != nil {
 			return nil, err
 		}
@@ -129,10 +173,23 @@ func (r *Remote) Pull(ctx context.Context, ref, outDir string) ([]string, error)
 	return paths, nil
 }
 
-// resolveDataLayers fetches the manifest at tag
+// openPullCache opens (creating if needed) the OCI image layout backing the
+// pull cache at dir.
+func openPullCache(dir string) (*orasoci.Store, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create pull cache %s: %w", dir, err)
+	}
+	store, err := orasoci.New(dir)
+	if err != nil {
+		return nil, fmt.Errorf("open pull cache %s: %w", dir, err)
+	}
+	return store, nil
+}
+
+// resolveDataLayers fetches the manifest at tag from target
 // and returns the descriptors of the DB data layers, located by media type.
-func (r *Remote) resolveDataLayers(ctx context.Context, repo *orasremote.Repository, tag string) ([]ocispec.Descriptor, error) {
-	_, manifest, err := fetchManifest(ctx, repo, tag)
+func resolveDataLayers(ctx context.Context, target oras.ReadOnlyTarget, tag string) ([]ocispec.Descriptor, error) {
+	_, manifest, err := fetchManifest(ctx, target, tag)
 	if err != nil {
 		return nil, err
 	}
@@ -186,8 +243,10 @@ func fetchManifest(ctx context.Context, target oras.ReadOnlyTarget, tag string) 
 
 // newRepository builds an authenticated remote repository client for ref.
 func (r *Remote) newRepository(ref registry.Reference) (*orasremote.Repository, error) {
-	if err := requireDockerConfig(); err != nil {
-		return nil, err
+	if !r.config.AllowAnonymous {
+		if err := requireDockerConfig(); err != nil {
+			return nil, err
+		}
 	}
 	credStore, err := credentials.NewStoreFromDocker(credentials.StoreOptions{})
 	if err != nil {
@@ -211,8 +270,8 @@ const maxDecompressedLayerSize = 1 << 30
 // fetchAndExtractLayer streams the tar.gz blob described by desc
 // and writes each regular file it contains into outDir under its base name.
 // It returns the written file paths.
-func fetchAndExtractLayer(ctx context.Context, repo *orasremote.Repository, desc ocispec.Descriptor, outDir string) ([]string, error) {
-	readCloser, err := repo.Blobs().Fetch(ctx, desc)
+func fetchAndExtractLayer(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor, outDir string) ([]string, error) {
+	readCloser, err := fetcher.Fetch(ctx, desc)
 	if err != nil {
 		return nil, fmt.Errorf("fetch blob %s: %w", desc.Digest, err)
 	}

--- a/internal/sbomscannerdb/oci/remote_test.go
+++ b/internal/sbomscannerdb/oci/remote_test.go
@@ -80,6 +80,13 @@ func TestPushPull_RoundTrip(t *testing.T) {
 		assert.Equal(t, "data for "+layer.FileName, string(data))
 	}
 
+	// The pull leaves a persistent content-addressable cache behind; a second
+	// pull reuses it and still returns the same feed files.
+	assert.DirExists(t, filepath.Join(outDir, pullCacheDir))
+	paths2, err := remote.Pull(ctx, ref, outDir)
+	require.NoError(t, err)
+	assert.Equal(t, paths, paths2)
+
 	// Re-push is idempotent: all content is already present remotely.
 	_, err = remote.Push(ctx, store, ref)
 	require.NoError(t, err)

--- a/pkg/generated/applyconfiguration/storage/v1alpha1/vulnerability.go
+++ b/pkg/generated/applyconfiguration/storage/v1alpha1/vulnerability.go
@@ -48,6 +48,15 @@ type VulnerabilityApplyConfiguration struct {
 	Suppressed *bool `json:"suppressed,omitempty"`
 	// VEXStatus information
 	VEXStatus *VEXStatusApplyConfiguration `json:"vexStatus,omitempty"`
+	// KnownExploited is true when the CVE appears in the CISA Known Exploited
+	// Vulnerabilities (KEV) catalog, i.e. it is being actively exploited in the wild.
+	KnownExploited *bool `json:"knownExploited,omitempty"`
+	// EPSSScore is the Exploit Prediction Scoring System probability that the CVE
+	// will be exploited (0..1), as a string. Empty when no EPSS data is available.
+	EPSSScore *string `json:"epssScore,omitempty"`
+	// EPSSPercentile is the EPSS score's percentile rank (0..1), as a string.
+	// Empty when no EPSS data is available.
+	EPSSPercentile *string `json:"epssPercentile,omitempty"`
 }
 
 // VulnerabilityApplyConfiguration constructs a declarative configuration of the Vulnerability type for use with
@@ -193,5 +202,29 @@ func (b *VulnerabilityApplyConfiguration) WithSuppressed(value bool) *Vulnerabil
 // If called multiple times, the VEXStatus field is set to the value of the last call.
 func (b *VulnerabilityApplyConfiguration) WithVEXStatus(value *VEXStatusApplyConfiguration) *VulnerabilityApplyConfiguration {
 	b.VEXStatus = value
+	return b
+}
+
+// WithKnownExploited sets the KnownExploited field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the KnownExploited field is set to the value of the last call.
+func (b *VulnerabilityApplyConfiguration) WithKnownExploited(value bool) *VulnerabilityApplyConfiguration {
+	b.KnownExploited = &value
+	return b
+}
+
+// WithEPSSScore sets the EPSSScore field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EPSSScore field is set to the value of the last call.
+func (b *VulnerabilityApplyConfiguration) WithEPSSScore(value string) *VulnerabilityApplyConfiguration {
+	b.EPSSScore = &value
+	return b
+}
+
+// WithEPSSPercentile sets the EPSSPercentile field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EPSSPercentile field is set to the value of the last call.
+func (b *VulnerabilityApplyConfiguration) WithEPSSPercentile(value string) *VulnerabilityApplyConfiguration {
+	b.EPSSPercentile = &value
 	return b
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -1229,6 +1229,27 @@ func schema_sbomscanner_api_storage_v1alpha1_Vulnerability(ref common.ReferenceC
 							Ref:         ref(v1alpha1.VEXStatus{}.OpenAPIModelName()),
 						},
 					},
+					"knownExploited": {
+						SchemaProps: spec.SchemaProps{
+							Description: "KnownExploited is true when the CVE appears in the CISA Known Exploited Vulnerabilities (KEV) catalog, i.e. it is being actively exploited in the wild.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"epssScore": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EPSSScore is the Exploit Prediction Scoring System probability that the CVE will be exploited (0..1), as a string. Empty when no EPSS data is available.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"epssPercentile": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EPSSPercentile is the EPSS score's percentile rank (0..1), as a string. Empty when no EPSS data is available.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"cve", "purl", "installedVersion", "diffID", "severity", "suppressed"},
 			},

--- a/test/crd/storage.sbomscanner.kubewarden.io_nodevulnerabilityreports.yaml
+++ b/test/crd/storage.sbomscanner.kubewarden.io_nodevulnerabilityreports.yaml
@@ -107,6 +107,16 @@ spec:
                             description: DiffID of the image layer where the vulnerability
                               was introduced
                             type: string
+                          epssPercentile:
+                            description: |-
+                              EPSSPercentile is the EPSS score's percentile rank (0..1), as a string.
+                              Empty when no EPSS data is available.
+                            type: string
+                          epssScore:
+                            description: |-
+                              EPSSScore is the Exploit Prediction Scoring System probability that the CVE
+                              will be exploited (0..1), as a string. Empty when no EPSS data is available.
+                            type: string
                           fixedVersions:
                             description: FixedVersions is the list of versions where
                               the vulnerability is fixed
@@ -117,6 +127,11 @@ spec:
                             description: InstalledVersion of the package that was
                               found
                             type: string
+                          knownExploited:
+                            description: |-
+                              KnownExploited is true when the CVE appears in the CISA Known Exploited
+                              Vulnerabilities (KEV) catalog, i.e. it is being actively exploited in the wild.
+                            type: boolean
                           packageName:
                             description: |-
                               PackageName is the name of the vulnerable package

--- a/test/crd/storage.sbomscanner.kubewarden.io_vulnerabilityreports.yaml
+++ b/test/crd/storage.sbomscanner.kubewarden.io_vulnerabilityreports.yaml
@@ -130,6 +130,16 @@ spec:
                             description: DiffID of the image layer where the vulnerability
                               was introduced
                             type: string
+                          epssPercentile:
+                            description: |-
+                              EPSSPercentile is the EPSS score's percentile rank (0..1), as a string.
+                              Empty when no EPSS data is available.
+                            type: string
+                          epssScore:
+                            description: |-
+                              EPSSScore is the Exploit Prediction Scoring System probability that the CVE
+                              will be exploited (0..1), as a string. Empty when no EPSS data is available.
+                            type: string
                           fixedVersions:
                             description: FixedVersions is the list of versions where
                               the vulnerability is fixed
@@ -140,6 +150,11 @@ spec:
                             description: InstalledVersion of the package that was
                               found
                             type: string
+                          knownExploited:
+                            description: |-
+                              KnownExploited is true when the CVE appears in the CISA Known Exploited
+                              Vulnerabilities (KEV) catalog, i.e. it is being actively exploited in the wild.
+                            type: boolean
                           packageName:
                             description: |-
                               PackageName is the name of the vulnerable package

--- a/test/crd/storage.sbomscanner.kubewarden.io_workloadscanreports.yaml
+++ b/test/crd/storage.sbomscanner.kubewarden.io_workloadscanreports.yaml
@@ -153,6 +153,16 @@ spec:
                                         description: DiffID of the image layer where
                                           the vulnerability was introduced
                                         type: string
+                                      epssPercentile:
+                                        description: |-
+                                          EPSSPercentile is the EPSS score's percentile rank (0..1), as a string.
+                                          Empty when no EPSS data is available.
+                                        type: string
+                                      epssScore:
+                                        description: |-
+                                          EPSSScore is the Exploit Prediction Scoring System probability that the CVE
+                                          will be exploited (0..1), as a string. Empty when no EPSS data is available.
+                                        type: string
                                       fixedVersions:
                                         description: FixedVersions is the list of
                                           versions where the vulnerability is fixed
@@ -163,6 +173,11 @@ spec:
                                         description: InstalledVersion of the package
                                           that was found
                                         type: string
+                                      knownExploited:
+                                        description: |-
+                                          KnownExploited is true when the CVE appears in the CISA Known Exploited
+                                          Vulnerabilities (KEV) catalog, i.e. it is being actively exploited in the wild.
+                                        type: boolean
                                       packageName:
                                         description: |-
                                           PackageName is the name of the vulnerable package


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->


This PR implements the enrichment vulnerability database integration with sbomscanner described in RFC [0010](https://github.com/kubewarden/sbomscanner/blob/main/docs/rfc/0010_enrichment_vulnerability_database.md). It introduces the ability to enrich sbomscanner's vulnerability reports with additional threat-intelligence context: KEV
(Known Exploited Vulnerabilities) and FIRST EPSS (Exploit Prediction Scoring System), distributed as a versioned OCI artifact and consumed by the worker at scan time.

### What's introduced

* `internal/enrichment` store: the worker-side consumer that lazily pulls the artifact into a local cache, holds in-memory per-CVE indices, and serves cheap lookups during scans. It degrades gracefully: a
missing/stale cache or an unreachable registry yields unenriched reports rather than failing the scan.
* (Node)VulnerabilityReport API fields: KnownExploited, EPSSScore, and EPSSPercentile added to the Vulnerability type, propagated through the generated CRDs, OpenAPI, and docs (VulnerabilityReport, NodeVulnerabilityReport,
WorkloadScanReport).
* Worker wiring: new flags to configure the enrichment source: `-enrichment-db-repository`, `-enrichment-db-cache-dir`, `-enrichment-db-skip-tls-verify`, `-enrichment-db-plain-http`. Enrichment runs in both
registry and node scanning modes; leaving the repository empty disables the feature.
* Startup cache cleanup: enrichment.CleanCache wipes any stale `<run-dir>/enrichment` cache on worker startup (both modes), preventing a persisted nextUpdate horizon from surviving a pod restart and making the
store wrongly believe its cache is fresh.

### How this changes current behaviour

* Vulnerability reports now carry exploit context. When an enrichment DB is configured, each CVE in a report can be flagged as known-exploited (KEV) and annotated with its EPSS score/percentile, enabling
prioritisation beyond CVSS severity alone.
* No change when disabled. With no `-enrichment-db-repository` set, behaviour is identical to before: reports contain no KEV/EPSS fields and nothing extra is pulled.
* Enrichment is best-effort and never blocks a scan. Registry outages, missing feeds, or a cold cache produce unenriched (but still complete) reports.
* Restart-safe cache. Previously, a worker restarting on a persistent volume could reuse a stale enrichment cache and skip refreshing it; the cache is now cleared on startup so the store always re-pulls a clean
copy.


## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
- [ ] I have updated the documentation via a pull request in [docs](https://github.com/kubewarden/docs/tree/main/docs/sbom-scanner) repository.
