### PR TITLE
fix(otel): job completion metrics

### DIFF
--- a/examples/dashboards/sbomscanner.json
+++ b/examples/dashboards/sbomscanner.json
@@ -22,7 +22,7 @@
     {
       "id": 201,
       "type": "stat",
-      "title": "Registry scans completed",
+      "title": "Registry scan jobs completed",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -73,7 +73,7 @@
     {
       "id": 202,
       "type": "stat",
-      "title": "Registry scans failed",
+      "title": "Registry scan jobs failed",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -128,7 +128,7 @@
     {
       "id": 203,
       "type": "stat",
-      "title": "Node scans completed",
+      "title": "Node scan jobs completed",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -179,7 +179,7 @@
     {
       "id": 204,
       "type": "stat",
-      "title": "Node scans failed",
+      "title": "Node scan jobs failed",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -234,7 +234,7 @@
     {
       "id": 205,
       "type": "stat",
-      "title": "Workload scans completed",
+      "title": "Workload scan jobs completed",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -285,7 +285,7 @@
     {
       "id": 206,
       "type": "stat",
-      "title": "Workload scans failed",
+      "title": "Workload scan jobs failed",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -340,7 +340,7 @@
     {
       "id": 207,
       "type": "timeseries",
-      "title": "Registry scans by result",
+      "title": "Registry scan jobs by result",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -388,7 +388,7 @@
     {
       "id": 208,
       "type": "timeseries",
-      "title": "Node scans by result",
+      "title": "Node scan jobs by result",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -436,7 +436,7 @@
     {
       "id": 209,
       "type": "timeseries",
-      "title": "Workload scans by result",
+      "title": "Workload scan jobs by result",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"

--- a/internal/controller/instrumentation.go
+++ b/internal/controller/instrumentation.go
@@ -8,12 +8,10 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/kubewarden/sbomscanner/api"
 	"github.com/kubewarden/sbomscanner/api/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/telemetry"
 )
@@ -31,8 +29,7 @@ type Instrumentation struct {
 	tracer            trace.Tracer
 	registryScanTicks metric.Int64Counter
 	nodeScanTicks     metric.Int64Counter
-	scanJobs          metric.Int64Counter
-	nodeScanJobs      metric.Int64Counter
+	jobs              *telemetry.JobMetrics
 }
 
 // NewInstrumentation creates a new Instrumentation.
@@ -53,28 +50,16 @@ func NewInstrumentation(tracer trace.Tracer, meter metric.Meter) (*Instrumentati
 		return nil, fmt.Errorf("creating controller.node_scan.ticks counter: %w", err)
 	}
 
-	scanJobs, err := meter.Int64Counter(
-		"sbomscanner.scanjobs",
-		metric.WithDescription("Number of ScanJobs that reached a terminal state."),
-	)
+	jobs, err := telemetry.NewJobMetrics(meter)
 	if err != nil {
-		return nil, fmt.Errorf("creating sbomscanner.scanjobs counter: %w", err)
-	}
-
-	nodeScanJobs, err := meter.Int64Counter(
-		"sbomscanner.nodescanjobs",
-		metric.WithDescription("Number of NodeScanJobs that reached a terminal state."),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("creating sbomscanner.nodescanjobs counter: %w", err)
+		return nil, fmt.Errorf("creating job metrics: %w", err)
 	}
 
 	return &Instrumentation{
 		tracer:            tracer,
 		registryScanTicks: registryScanTicks,
 		nodeScanTicks:     nodeScanTicks,
-		scanJobs:          scanJobs,
-		nodeScanJobs:      nodeScanJobs,
+		jobs:              jobs,
 	}, nil
 }
 
@@ -88,6 +73,18 @@ func (i *Instrumentation) recordNodeScanTick(ctx context.Context, result string)
 	i.nodeScanTicks.Add(ctx, 1, metric.WithAttributes(attribute.String("result", result)))
 }
 
+// recordScanJobFinished counts a ScanJob whose terminal status this process persisted.
+// It is a no-op when the job is not in a terminal state.
+func (i *Instrumentation) recordScanJobFinished(ctx context.Context, scanJob *v1alpha1.ScanJob) {
+	i.jobs.RecordScanJobFinished(ctx, scanJob)
+}
+
+// recordNodeScanJobFinished counts a NodeScanJob whose terminal status this process persisted.
+// It is a no-op when the job is not in a terminal state.
+func (i *Instrumentation) recordNodeScanJobFinished(ctx context.Context, nodeScanJob *v1alpha1.NodeScanJob) {
+	i.jobs.RecordNodeScanJobFinished(ctx, nodeScanJob)
+}
+
 // startJobTrace starts a fresh trace for a job being created.
 //
 //nolint:spancheck // The span is returned to the caller, which is responsible for ending it.
@@ -97,19 +94,6 @@ func (i *Instrumentation) startJobTrace(ctx context.Context, name string, attrs 
 		trace.WithLinks(trace.LinkFromContext(ctx)),
 		trace.WithAttributes(attrs...),
 	)
-}
-
-// scanJobTransitions returns an informer event handler counting ScanJobs that reach a terminal state,
-// labelled with the scan source (registry or workload).
-func (i *Instrumentation) scanJobTransitions() toolscache.ResourceEventHandler {
-	return jobTransitions(i.scanJobs, func(job client.Object) []attribute.KeyValue {
-		return []attribute.KeyValue{attribute.String("source", scanJobSource(job))}
-	})
-}
-
-// nodeScanJobTransitions returns an informer event handler counting NodeScanJobs that reach a terminal state.
-func (i *Instrumentation) nodeScanJobTransitions() toolscache.ResourceEventHandler {
-	return jobTransitions(i.nodeScanJobs, nil)
 }
 
 // instrumentedReconciler decorates a reconcile.Reconciler with a span per call,
@@ -202,42 +186,6 @@ func reconcileOutcome(result ctrl.Result, err error) string {
 		return resultRequeue
 	default:
 		return resultSuccess
-	}
-}
-
-// isTerminal reports whether the job reached a final state.
-func isTerminal(job v1alpha1.ConditionedJob) bool {
-	return job.IsComplete() || job.IsFailed()
-}
-
-// scanJobSource returns the bounded source label of a ScanJob:
-// workload when the job carries the workloadscan label
-// (stamped by the runner for jobs created against workloadscan-managed registries), registry otherwise.
-func scanJobSource(job client.Object) string {
-	if job.GetLabels()[api.LabelWorkloadScanKey] == api.LabelWorkloadScanValue {
-		return "workload"
-	}
-	return "registry"
-}
-
-// jobTransitions returns an informer event handler that increments counter each time a job finishes
-// (its status transitions to complete or failed).
-// It misses jobs that finish while the controller is not running.
-func jobTransitions(counter metric.Int64Counter, extraAttributes func(client.Object) []attribute.KeyValue) toolscache.ResourceEventHandler {
-	return toolscache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(oldObj, newObj any) {
-			oldJob, oldOK := oldObj.(v1alpha1.ConditionedJob)
-			newJob, newOK := newObj.(v1alpha1.ConditionedJob)
-			if !oldOK || !newOK || isTerminal(oldJob) || !isTerminal(newJob) {
-				return
-			}
-
-			attrs := []attribute.KeyValue{attribute.String("result", jobStatus(newJob))}
-			if newObject, ok := newObj.(client.Object); ok && extraAttributes != nil {
-				attrs = append(attrs, extraAttributes(newObject)...)
-			}
-			counter.Add(context.Background(), 1, metric.WithAttributes(attrs...))
-		},
 	}
 }
 

--- a/internal/controller/instrumentation_test.go
+++ b/internal/controller/instrumentation_test.go
@@ -12,7 +12,6 @@ import (
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
@@ -24,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/kubewarden/sbomscanner/api"
 	"github.com/kubewarden/sbomscanner/api/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/telemetry"
 )
@@ -40,22 +38,21 @@ func (f *fakeReconciler) Reconcile(context.Context, ctrl.Request) (ctrl.Result, 
 }
 
 // newTestInstrumentation builds an Instrumentation backed by in-memory SDK providers,
-// returning the span recorder and metric reader used for assertions.
-func newTestInstrumentation(t *testing.T) (*Instrumentation, *tracetest.SpanRecorder, *sdkmetric.ManualReader) {
+// returning the span recorder used for assertions.
+func newTestInstrumentation(t *testing.T) (*Instrumentation, *tracetest.SpanRecorder) {
 	t.Helper()
 
 	spanRecorder := tracetest.NewSpanRecorder()
 	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
 	t.Cleanup(func() { _ = tracerProvider.Shutdown(context.Background()) })
 
-	reader := sdkmetric.NewManualReader()
-	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meterProvider := sdkmetric.NewMeterProvider()
 	t.Cleanup(func() { _ = meterProvider.Shutdown(context.Background()) })
 
 	instrumentation, err := NewInstrumentation(tracerProvider.Tracer("test"), meterProvider.Meter("test"))
 	require.NoError(t, err)
 
-	return instrumentation, spanRecorder, reader
+	return instrumentation, spanRecorder
 }
 
 // newFakeReader returns a fake cached client seeded with the given objects,
@@ -80,7 +77,7 @@ func newNoopInstrumentation() *Instrumentation {
 }
 
 func TestInstrumentedReconciler_Success(t *testing.T) {
-	instrumentation, spanRecorder, _ := newTestInstrumentation(t)
+	instrumentation, spanRecorder := newTestInstrumentation(t)
 	reconciler := instrumentReconciler(instrumentation, "ScanJob", "ScanJob", &fakeReconciler{})
 
 	request := ctrl.Request{}
@@ -102,7 +99,7 @@ func TestInstrumentedReconciler_Success(t *testing.T) {
 }
 
 func TestInstrumentedReconciler_Error(t *testing.T) {
-	instrumentation, spanRecorder, _ := newTestInstrumentation(t)
+	instrumentation, spanRecorder := newTestInstrumentation(t)
 	notFound := apierrors.NewNotFound(schema.GroupResource{Group: v1alpha1.GroupVersion.Group, Resource: "scanjobs"}, "my-job")
 	reconciler := instrumentReconciler(instrumentation, "ScanJob", "ScanJob", &fakeReconciler{err: notFound})
 
@@ -116,7 +113,7 @@ func TestInstrumentedReconciler_Error(t *testing.T) {
 }
 
 func TestInstrumentedReconciler_Requeue(t *testing.T) {
-	instrumentation, spanRecorder, _ := newTestInstrumentation(t)
+	instrumentation, spanRecorder := newTestInstrumentation(t)
 	reconciler := instrumentReconciler(instrumentation, "ScanJob", "ScanJob", &fakeReconciler{result: ctrl.Result{RequeueAfter: time.Minute}})
 
 	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{})
@@ -132,7 +129,7 @@ func TestInstrumentedReconciler_Requeue(t *testing.T) {
 // trace carried by the object's traceparent annotation, resolved before the span starts.
 func TestInstrumentedReconciler_JoinsJobTrace(t *testing.T) {
 	otel.SetTextMapPropagator(propagation.TraceContext{})
-	instrumentation, spanRecorder, _ := newTestInstrumentation(t)
+	instrumentation, spanRecorder := newTestInstrumentation(t)
 
 	// Simulate the runner: a job trace injected into the object's annotations.
 	jobCtx, jobSpan := instrumentation.startJobTrace(context.Background(), "RegistryScanRunner.CreateScanJob")
@@ -165,7 +162,7 @@ func TestInstrumentedReconciler_JoinsJobTrace(t *testing.T) {
 // linked back to the runner tick span instead of being parented under it.
 func TestStartJobTrace(t *testing.T) {
 	otel.SetTextMapPropagator(propagation.TraceContext{})
-	instrumentation, spanRecorder, _ := newTestInstrumentation(t)
+	instrumentation, spanRecorder := newTestInstrumentation(t)
 
 	tickCtx, tickSpan := instrumentation.tracer.Start(context.Background(), "runner cycle")
 	defer tickSpan.End()
@@ -203,71 +200,6 @@ func TestJobStatus(t *testing.T) {
 
 	scanJob.MarkFailed(v1alpha1.ReasonScanJobRegistryNotFound, "failed")
 	assert.Equal(t, "failed", jobStatus(scanJob))
-}
-
-// scanJobInStatus returns a ScanJob in the given lifecycle status for transition tests.
-func scanJobInStatus(status string) *v1alpha1.ScanJob {
-	scanJob := &v1alpha1.ScanJob{}
-	scanJob.InitializeConditions()
-	switch status {
-	case "scheduled":
-		scanJob.MarkScheduled(v1alpha1.ReasonScanJobScheduled, "scheduled")
-	case "in_progress":
-		scanJob.MarkInProgress(v1alpha1.ReasonScanJobImageScanInProgress, "in progress")
-	case "complete":
-		scanJob.MarkComplete(v1alpha1.ReasonScanJobAllImagesScanned, "complete")
-	case "failed":
-		scanJob.MarkFailed(v1alpha1.ReasonScanJobRegistryNotFound, "failed")
-	}
-	return scanJob
-}
-
-// collectJobResults returns the sbomscanner.scanjobs data points keyed by "result/source", empty when absent.
-func collectJobResults(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
-	t.Helper()
-
-	var resourceMetrics metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(context.Background(), &resourceMetrics))
-
-	results := map[string]int64{}
-	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
-		for _, m := range scopeMetrics.Metrics {
-			if m.Name != "sbomscanner.scanjobs" {
-				continue
-			}
-			sum, ok := m.Data.(metricdata.Sum[int64])
-			require.True(t, ok)
-			for _, point := range sum.DataPoints {
-				key := attrValue(point.Attributes, "result") + "/" + attrValue(point.Attributes, "source")
-				results[key] += point.Value
-			}
-		}
-	}
-	return results
-}
-
-// TestScanJobTransitions asserts that only transitions into a terminal state are counted,
-// labelled with the scan source.
-func TestScanJobTransitions(t *testing.T) {
-	instrumentation, _, reader := newTestInstrumentation(t)
-	handler := instrumentation.scanJobTransitions()
-
-	workloadJob := scanJobInStatus("complete")
-	workloadJob.Labels = map[string]string{api.LabelWorkloadScanKey: api.LabelWorkloadScanValue}
-
-	handler.OnUpdate(scanJobInStatus("pending"), scanJobInStatus("failed"))
-	handler.OnUpdate(scanJobInStatus("in_progress"), scanJobInStatus("complete"))
-	handler.OnUpdate(scanJobInStatus("in_progress"), workloadJob)
-	handler.OnUpdate(scanJobInStatus("pending"), scanJobInStatus("scheduled")) // non-terminal transition
-	handler.OnUpdate(scanJobInStatus("failed"), scanJobInStatus("failed"))     // already terminal, e.g. a resync
-	handler.OnUpdate(scanJobInStatus("complete"), scanJobInStatus("complete")) // already terminal, e.g. a resync
-
-	results := collectJobResults(t, reader)
-	assert.Equal(t, map[string]int64{
-		"failed/registry":   1,
-		"complete/registry": 1,
-		"complete/workload": 1,
-	}, results)
 }
 
 // attrValue returns the string form of the attribute with the given key, or "" when absent.

--- a/internal/controller/nodescanjob_controller.go
+++ b/internal/controller/nodescanjob_controller.go
@@ -32,6 +32,8 @@ type NodeScanJobReconciler struct {
 
 	Scheme    *runtime.Scheme
 	Publisher messaging.Publisher
+
+	instrumentation *Instrumentation
 }
 
 // +kubebuilder:rbac:groups=sbomscanner.kubewarden.io,resources=nodescanjobs,verbs=get;list;watch;create;update;patch;delete
@@ -73,6 +75,8 @@ func (r *NodeScanJobReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			if err := r.Status().Update(ctx, nodeScanJob); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update NodeScanJob status: %w", err)
 			}
+			// The job was pending on entry, so a terminal status persisted here is a fresh completion.
+			r.instrumentation.recordNodeScanJobFinished(ctx, nodeScanJob)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get NodeScanConfiguration: %w", err)
@@ -87,6 +91,7 @@ func (r *NodeScanJobReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if err := r.Status().Update(ctx, nodeScanJob); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update NodeScanJob status: %w", err)
 		}
+		r.instrumentation.recordNodeScanJobFinished(ctx, nodeScanJob)
 		return ctrl.Result{}, nil
 	}
 
@@ -95,6 +100,7 @@ func (r *NodeScanJobReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err := r.Status().Update(ctx, nodeScanJob); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update NodeScanJob status: %w", err)
 	}
+	r.instrumentation.recordNodeScanJobFinished(ctx, nodeScanJob)
 
 	log.V(1).Info("Successfully reconciled NodeScanJob", "nodeScanJob", req.NamespacedName)
 	return reconcileResult, reconcileErr
@@ -254,16 +260,9 @@ func (r *NodeScanJobReconciler) cleanupOldNodeScanJobs(ctx context.Context, curr
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeScanJobReconciler) SetupWithManager(mgr ctrl.Manager, instrumentation *Instrumentation) error {
-	// Count job completions on the controller's informer, observing every status writer.
-	informer, err := mgr.GetCache().GetInformer(context.Background(), &v1alpha1.NodeScanJob{})
-	if err != nil {
-		return fmt.Errorf("failed to get NodeScanJob informer: %w", err)
-	}
-	if _, err := informer.AddEventHandler(instrumentation.nodeScanJobTransitions()); err != nil {
-		return fmt.Errorf("failed to register NodeScanJob transitions handler: %w", err)
-	}
+	r.instrumentation = instrumentation
 
-	err = ctrl.NewControllerManagedBy(mgr).
+	err := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.NodeScanJob{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: maxConcurrentReconciles,

--- a/internal/controller/nodescanjob_controller_test.go
+++ b/internal/controller/nodescanjob_controller_test.go
@@ -33,9 +33,10 @@ var _ = Describe("NodeScanJob Controller", func() {
 			By("Creating a new NodeScanJobReconciler")
 			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
 			reconciler = NodeScanJobReconciler{
-				Client:    k8sClient,
-				Publisher: mockPublisher,
-				Scheme:    k8sClient.Scheme(),
+				Client:          k8sClient,
+				Publisher:       mockPublisher,
+				Scheme:          k8sClient.Scheme(),
+				instrumentation: newNoopInstrumentation(),
 			}
 
 			By("Creating a NodeScanConfiguration")
@@ -139,9 +140,10 @@ var _ = Describe("NodeScanJob Controller", func() {
 			By("Creating a new NodeScanJobReconciler")
 			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
 			reconciler = NodeScanJobReconciler{
-				Client:    k8sClient,
-				Publisher: mockPublisher,
-				Scheme:    k8sClient.Scheme(),
+				Client:          k8sClient,
+				Publisher:       mockPublisher,
+				Scheme:          k8sClient.Scheme(),
+				instrumentation: newNoopInstrumentation(),
 			}
 
 			By("Creating a Node")
@@ -194,9 +196,10 @@ var _ = Describe("NodeScanJob Controller", func() {
 			By("Creating a new NodeScanJobReconciler")
 			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
 			reconciler = NodeScanJobReconciler{
-				Client:    k8sClient,
-				Publisher: mockPublisher,
-				Scheme:    k8sClient.Scheme(),
+				Client:          k8sClient,
+				Publisher:       mockPublisher,
+				Scheme:          k8sClient.Scheme(),
+				instrumentation: newNoopInstrumentation(),
 			}
 
 			By("Creating a NodeScanConfiguration with a nodeSelector")
@@ -267,9 +270,10 @@ var _ = Describe("NodeScanJob Controller", func() {
 			By("Creating a new NodeScanJobReconciler")
 			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
 			reconciler = NodeScanJobReconciler{
-				Client:    k8sClient,
-				Publisher: mockPublisher,
-				Scheme:    k8sClient.Scheme(),
+				Client:          k8sClient,
+				Publisher:       mockPublisher,
+				Scheme:          k8sClient.Scheme(),
+				instrumentation: newNoopInstrumentation(),
 			}
 
 			By("Creating a NodeScanConfiguration with platform filter")
@@ -344,9 +348,10 @@ var _ = Describe("NodeScanJob Controller", func() {
 			By("Creating a new NodeScanJobReconciler")
 			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
 			reconciler = NodeScanJobReconciler{
-				Client:    k8sClient,
-				Publisher: mockPublisher,
-				Scheme:    k8sClient.Scheme(),
+				Client:          k8sClient,
+				Publisher:       mockPublisher,
+				Scheme:          k8sClient.Scheme(),
+				instrumentation: newNoopInstrumentation(),
 			}
 
 			By("Creating a NodeScanConfiguration")

--- a/internal/controller/scanjob_controller.go
+++ b/internal/controller/scanjob_controller.go
@@ -33,6 +33,8 @@ type ScanJobReconciler struct {
 
 	Scheme    *runtime.Scheme
 	Publisher messaging.Publisher
+
+	instrumentation *Instrumentation
 }
 
 // +kubebuilder:rbac:groups=sbomscanner.kubewarden.io,resources=scanjobs,verbs=get;list;watch;create;update;patch;delete
@@ -72,6 +74,9 @@ func (r *ScanJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err := r.Status().Update(ctx, scanJob); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update ScanJob status: %w", err)
 	}
+
+	// The job was pending on entry, so a terminal status persisted here is a fresh completion.
+	r.instrumentation.recordScanJobFinished(ctx, scanJob)
 
 	return reconcileResult, reconcileErr
 }
@@ -224,16 +229,9 @@ func validateScanJobTargets(scanJob *v1alpha1.ScanJob, registry *v1alpha1.Regist
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ScanJobReconciler) SetupWithManager(mgr ctrl.Manager, instrumentation *Instrumentation) error {
-	// Count job completions on the controller's informer, observing every status writer.
-	informer, err := mgr.GetCache().GetInformer(context.Background(), &v1alpha1.ScanJob{})
-	if err != nil {
-		return fmt.Errorf("failed to get ScanJob informer: %w", err)
-	}
-	if _, err := informer.AddEventHandler(instrumentation.scanJobTransitions()); err != nil {
-		return fmt.Errorf("failed to register ScanJob transitions handler: %w", err)
-	}
+	r.instrumentation = instrumentation
 
-	err = ctrl.NewControllerManagedBy(mgr).
+	err := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.ScanJob{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: maxConcurrentReconciles,

--- a/internal/controller/scanjob_controller_test.go
+++ b/internal/controller/scanjob_controller_test.go
@@ -33,9 +33,10 @@ var _ = Describe("ScanJob Controller", func() {
 			By("Creating a new ScanJobReconciler")
 			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
 			reconciler = ScanJobReconciler{
-				Client:    k8sClient,
-				Publisher: mockPublisher,
-				Scheme:    k8sClient.Scheme(),
+				Client:          k8sClient,
+				Publisher:       mockPublisher,
+				Scheme:          k8sClient.Scheme(),
+				instrumentation: newNoopInstrumentation(),
 			}
 
 			By("Creating a Registry")
@@ -138,9 +139,10 @@ var _ = Describe("ScanJob Controller", func() {
 			By("Creating a new ScanJobReconciler")
 			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
 			reconciler = ScanJobReconciler{
-				Client:    k8sClient,
-				Publisher: mockPublisher,
-				Scheme:    k8sClient.Scheme(),
+				Client:          k8sClient,
+				Publisher:       mockPublisher,
+				Scheme:          k8sClient.Scheme(),
+				instrumentation: newNoopInstrumentation(),
 			}
 
 			By("Creating a ScanJob with non-existent Registry")
@@ -185,9 +187,10 @@ var _ = Describe("ScanJob Controller", func() {
 		BeforeEach(func(ctx context.Context) {
 			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
 			reconciler = ScanJobReconciler{
-				Client:    k8sClient,
-				Publisher: mockPublisher,
-				Scheme:    k8sClient.Scheme(),
+				Client:          k8sClient,
+				Publisher:       mockPublisher,
+				Scheme:          k8sClient.Scheme(),
+				instrumentation: newNoopInstrumentation(),
 			}
 
 			By("Creating a Registry with known repositories and match conditions")
@@ -270,9 +273,10 @@ var _ = Describe("ScanJob Controller", func() {
 			By("Creating a new ScanJobReconciler")
 			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
 			reconciler = ScanJobReconciler{
-				Client:    k8sClient,
-				Publisher: mockPublisher,
-				Scheme:    k8sClient.Scheme(),
+				Client:          k8sClient,
+				Publisher:       mockPublisher,
+				Scheme:          k8sClient.Scheme(),
+				instrumentation: newNoopInstrumentation(),
 			}
 
 			By("Creating a completed ScanJob")
@@ -315,9 +319,10 @@ var _ = Describe("ScanJob Controller", func() {
 			By("Creating a new ScanJobReconciler")
 			mockPublisher = messagingMocks.NewMockPublisher(GinkgoT())
 			reconciler = ScanJobReconciler{
-				Client:    k8sClient,
-				Publisher: mockPublisher,
-				Scheme:    k8sClient.Scheme(),
+				Client:          k8sClient,
+				Publisher:       mockPublisher,
+				Scheme:          k8sClient.Scheme(),
+				instrumentation: newNoopInstrumentation(),
 			}
 			By("Creating a Registry")
 			registry = v1alpha1.Registry{

--- a/internal/controller/vulnerabilityreport_controller.go
+++ b/internal/controller/vulnerabilityreport_controller.go
@@ -21,6 +21,8 @@ type VulnerabilityReportReconciler struct {
 	client.Client
 
 	Scheme *runtime.Scheme
+
+	instrumentation *Instrumentation
 }
 
 // +kubebuilder:rbac:groups=storage.sbomscanner.kubewarden.io,resources=vulnerabilityreports,verbs=get;list;watch
@@ -88,7 +90,8 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 	scanJob.Status.ScannedImagesCount = len(vulnerabilityReports.Items)
 	// If the ScanJob is failed, we don't want to override its status conditions.
 	// We still update the ScannedImagesCount in case some reports were generated before the failure.
-	if !scanJob.IsFailed() {
+	wasFailed := scanJob.IsFailed()
+	if !wasFailed {
 		if scanJob.Status.ScannedImagesCount == scanJob.Status.ImagesCount {
 			now := metav1.Now()
 			scanJob.Status.CompletionTime = &now
@@ -101,11 +104,19 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, fmt.Errorf("failed to update ScanJob status: %w", err)
 	}
 
+	// Count the completion persisted here; a job that was already failed
+	// was counted by the writer that failed it.
+	if !wasFailed {
+		r.instrumentation.recordScanJobFinished(ctx, scanJob)
+	}
+
 	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *VulnerabilityReportReconciler) SetupWithManager(mgr ctrl.Manager, instrumentation *Instrumentation) error {
+	r.instrumentation = instrumentation
+
 	err := ctrl.NewControllerManagedBy(mgr).
 		// Watch only metadata to reduce memory usage and API server load.
 		For(&storagev1alpha1.VulnerabilityReport{}, builder.OnlyMetadata).

--- a/internal/controller/vulnerabilityreport_controller_test.go
+++ b/internal/controller/vulnerabilityreport_controller_test.go
@@ -250,8 +250,9 @@ var _ = Describe("VulnerabilityReport Controller", func() {
 			It("should skip reconciliation without error to avoid reconciliation loops", func(ctx context.Context) {
 				By("Creating a VulnerabilityReport reconciler")
 				reconciler := VulnerabilityReportReconciler{
-					Client: mgrClient,
-					Scheme: k8sClient.Scheme(),
+					Client:          mgrClient,
+					Scheme:          k8sClient.Scheme(),
+					instrumentation: newNoopInstrumentation(),
 				}
 
 				By("Reconciling the VulnerabilityReport")
@@ -287,8 +288,9 @@ var _ = Describe("VulnerabilityReport Controller", func() {
 			It("should skip reconciliation without error to avoid reconciliation loops", func(ctx context.Context) {
 				By("Creating a VulnerabilityReport reconciler")
 				reconciler := VulnerabilityReportReconciler{
-					Client: mgrClient,
-					Scheme: k8sClient.Scheme(),
+					Client:          mgrClient,
+					Scheme:          k8sClient.Scheme(),
+					instrumentation: newNoopInstrumentation(),
 				}
 
 				By("Reconciling the VulnerabilityReport")

--- a/internal/handlers/create_catalog.go
+++ b/internal/handlers/create_catalog.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kubewarden/sbomscanner/internal/handlers/dockerauth"
 	registryclient "github.com/kubewarden/sbomscanner/internal/handlers/registry"
 	"github.com/kubewarden/sbomscanner/internal/messaging"
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
 )
 
 // CreateCatalogHandler is a handler for creating a catalog of images in a registry.
@@ -86,6 +87,7 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message messaging.Mes
 	// It is possible that the controller is slow to set the status condition "Scheduled" to true,
 	// so we might encounter conflicts when setting the status condition to "InProgress".
 	scanJob := &v1alpha1.ScanJob{}
+	var alreadyFinished bool
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err = h.k8sClient.Get(ctx, client.ObjectKey{
 			Name:      createCatalogMessage.ScanJob.Name,
@@ -101,6 +103,13 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message messaging.Mes
 			)
 		}
 
+		// A finished job means this message is a redelivery: skip it, so the job
+		// is not moved back to in-progress and completed (and counted) again.
+		if telemetry.JobFinished(scanJob) {
+			alreadyFinished = true
+			return nil
+		}
+
 		scanJob.MarkInProgress(v1alpha1.ReasonScanJobCatalogCreationInProgress, "Catalog creation in progress")
 		return h.k8sClient.Status().Update(ctx, scanJob)
 	})
@@ -112,6 +121,11 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message messaging.Mes
 			return nil
 		}
 		return fmt.Errorf("cannot update scan job status %s/%s: %w", createCatalogMessage.ScanJob.Namespace, createCatalogMessage.ScanJob.Name, err)
+	}
+	if alreadyFinished {
+		h.logger.InfoContext(ctx, "ScanJob is already finished, stopping catalog creation", "scanjob", createCatalogMessage.ScanJob.Name, "namespace", createCatalogMessage.ScanJob.Namespace)
+		recordSpanSkipReason(ctx, skipReasonJobFinished)
+		return nil
 	}
 
 	// Retrieve the registry from the scan job annotations.
@@ -278,6 +292,7 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message messaging.Mes
 
 	// It is possible that the controller is slow to set the status condition "Scheduled" to true,
 	// so we might encounter conflicts when setting the status conditions.
+	var wasFinished bool
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err = h.k8sClient.Get(ctx, types.NamespacedName{
 			Name:      scanJob.Name,
@@ -293,6 +308,7 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message messaging.Mes
 			)
 		}
 
+		wasFinished = telemetry.JobFinished(scanJob)
 		if len(discoveredImages) == 0 {
 			h.logger.InfoContext(ctx, "No images to process", "scanjob", scanJob.Name, "namespace", scanJob.Namespace)
 			scanJob.MarkComplete(v1alpha1.ReasonScanJobNoImagesToScan, "No images to process")
@@ -312,6 +328,12 @@ func (h *CreateCatalogHandler) Handle(ctx context.Context, message messaging.Mes
 			return nil
 		}
 		return fmt.Errorf("cannot update scan job status %s/%s: %w", createCatalogMessage.ScanJob.Namespace, createCatalogMessage.ScanJob.Name, err)
+	}
+
+	// Count the completion persisted here (the no-images case); a job that was
+	// already finished was counted by the writer that finished it.
+	if !wasFinished {
+		h.instrumentation.recordScanJobFinished(ctx, scanJob)
 	}
 
 	for _, image := range discoveredImages {

--- a/internal/handlers/create_catalog_test.go
+++ b/internal/handlers/create_catalog_test.go
@@ -658,6 +658,9 @@ func TestCreateCatalogHandler_Handle_StopProcessing(t *testing.T) {
 		},
 	}
 
+	completeScanJob := scanJob.DeepCopy()
+	completeScanJob.MarkComplete(v1alpha1.ReasonScanJobNoImagesToScan, "No images to process")
+
 	tests := []struct {
 		name               string
 		existingObjects    []runtime.Object
@@ -668,6 +671,13 @@ func TestCreateCatalogHandler_Handle_StopProcessing(t *testing.T) {
 		{
 			name:               "scanjob not found initially",
 			existingObjects:    []runtime.Object{registry},
+			setup:              func(_ client.Client, _ *v1alpha1.ScanJob) {},
+			interceptorFuncs:   interceptor.Funcs{},
+			expectedImageCount: 0,
+		},
+		{
+			name:               "scanjob already finished, e.g. a redelivered message",
+			existingObjects:    []runtime.Object{registry, completeScanJob},
 			setup:              func(_ client.Client, _ *v1alpha1.ScanJob) {},
 			interceptorFuncs:   interceptor.Funcs{},
 			expectedImageCount: 0,

--- a/internal/handlers/instrumentation.go
+++ b/internal/handlers/instrumentation.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kubewarden/sbomscanner/api/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/messaging"
 	"github.com/kubewarden/sbomscanner/internal/telemetry"
 )
@@ -28,6 +29,7 @@ const (
 	skipReasonJobNotFound    = "job_not_found"
 	skipReasonUIDMismatch    = "uid_mismatch"
 	skipReasonJobFailed      = "job_failed"
+	skipReasonJobFinished    = "job_finished"
 	skipReasonObjectNotFound = "object_not_found"
 )
 
@@ -47,6 +49,7 @@ type Instrumentation struct {
 	registryCallDuration metric.Float64Histogram
 	trivyDuration        metric.Float64Histogram
 	handlerErrors        metric.Int64Counter
+	jobs                 *telemetry.JobMetrics
 }
 
 // NewInstrumentation creates a new Instrumentation.
@@ -94,6 +97,11 @@ func NewInstrumentation(tracer trace.Tracer, meter metric.Meter) (*Instrumentati
 		return nil, fmt.Errorf("creating worker.handler.errors counter: %w", err)
 	}
 
+	jobs, err := telemetry.NewJobMetrics(meter)
+	if err != nil {
+		return nil, fmt.Errorf("creating job metrics: %w", err)
+	}
+
 	return &Instrumentation{
 		tracer:               tracer,
 		scanDuration:         scanDuration,
@@ -101,7 +109,20 @@ func NewInstrumentation(tracer trace.Tracer, meter metric.Meter) (*Instrumentati
 		registryCallDuration: registryCallDuration,
 		trivyDuration:        trivyDuration,
 		handlerErrors:        handlerErrors,
+		jobs:                 jobs,
 	}, nil
+}
+
+// recordScanJobFinished counts a ScanJob whose terminal status this process persisted.
+// It is a no-op when the job is not in a terminal state.
+func (i *Instrumentation) recordScanJobFinished(ctx context.Context, scanJob *v1alpha1.ScanJob) {
+	i.jobs.RecordScanJobFinished(ctx, scanJob)
+}
+
+// recordNodeScanJobFinished counts a NodeScanJob whose terminal status this process persisted.
+// It is a no-op when the job is not in a terminal state.
+func (i *Instrumentation) recordNodeScanJobFinished(ctx context.Context, nodeScanJob *v1alpha1.NodeScanJob) {
+	i.jobs.RecordNodeScanJobFinished(ctx, nodeScanJob)
 }
 
 // recordHandled records the duration of one handled message, and counts the error when it failed.

--- a/internal/handlers/node_scan_sbom.go
+++ b/internal/handlers/node_scan_sbom.go
@@ -18,6 +18,7 @@ import (
 	storagev1alpha1 "github.com/kubewarden/sbomscanner/api/storage/v1alpha1"
 	"github.com/kubewarden/sbomscanner/api/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/messaging"
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
 )
 
 // NodeScanSBOMHandler handles SBOM scan requests for nodes.
@@ -87,9 +88,11 @@ func (h *NodeScanSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 		return nil
 	}
 
-	if scanJob.IsFailed() {
-		h.logger.InfoContext(ctx, "NodeScanJob is in failed state, stopping SBOM scan", "scanjob", nodeScanJobName, "namespace", nodeScanJobNamespace)
-		recordSpanSkipReason(ctx, skipReasonJobFailed)
+	// A finished job means this message is a redelivery: skip it, so the job
+	// is not moved back to in-progress and completed (and counted) again.
+	if telemetry.JobFinished(scanJob) {
+		h.logger.InfoContext(ctx, "NodeScanJob is already finished, stopping SBOM scan", "scanjob", nodeScanJobName, "namespace", nodeScanJobNamespace)
+		recordSpanSkipReason(ctx, skipReasonJobFinished)
 		return nil
 	}
 
@@ -171,6 +174,7 @@ func (h *NodeScanSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 		"namespace", nodeSBOMNamespace,
 	)
 
+	var wasFinished bool
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := h.k8sClient.Get(ctx, client.ObjectKey{
 			Name:      nodeScanJobName,
@@ -179,6 +183,7 @@ func (h *NodeScanSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 			return fmt.Errorf("failed to get ScanJob: %w", err)
 		}
 
+		wasFinished = telemetry.JobFinished(scanJob)
 		scanJob.MarkComplete(v1alpha1.ReasonNodeScanJobComplete, "NodeSBOM scanned successfully")
 		return h.k8sClient.Status().Update(ctx, scanJob)
 	})
@@ -190,6 +195,12 @@ func (h *NodeScanSBOMHandler) Handle(ctx context.Context, message messaging.Mess
 			return nil
 		}
 		return fmt.Errorf("failed to update NodeScanJob status: %w", err)
+	}
+
+	// Count the completion persisted here; a job that was already finished
+	// was counted by the writer that finished it.
+	if !wasFinished {
+		h.instrumentation.recordNodeScanJobFinished(ctx, scanJob)
 	}
 	h.logger.InfoContext(ctx, "NodeSBOM scanned",
 		"nodesbom", nodeSBOMName,

--- a/internal/handlers/node_scan_sbom_test.go
+++ b/internal/handlers/node_scan_sbom_test.go
@@ -134,6 +134,9 @@ func TestNodeScanSBOMHandler_Handle_StopProcessing(t *testing.T) {
 	failedNodeScanJob := nodeScanJob.DeepCopy()
 	failedNodeScanJob.MarkFailed(v1alpha1.ReasonScanJobInternalError, "kaboom")
 
+	completeNodeScanJob := nodeScanJob.DeepCopy()
+	completeNodeScanJob.MarkComplete(v1alpha1.ReasonNodeScanJobComplete, "done")
+
 	tests := []struct {
 		name            string
 		nodeScanJob     *v1alpha1.NodeScanJob
@@ -153,6 +156,11 @@ func TestNodeScanSBOMHandler_Handle_StopProcessing(t *testing.T) {
 			name:            "nodescanjob is failed",
 			nodeScanJob:     failedNodeScanJob,
 			existingObjects: []runtime.Object{failedNodeScanJob, nodeSBOM, vexHubs},
+		},
+		{
+			name:            "nodescanjob is complete, e.g. a redelivered message",
+			nodeScanJob:     completeNodeScanJob,
+			existingObjects: []runtime.Object{completeNodeScanJob, nodeSBOM, vexHubs},
 		},
 		{
 			name:            "nodesbom not found",

--- a/internal/handlers/nodescanjob_failure.go
+++ b/internal/handlers/nodescanjob_failure.go
@@ -12,12 +12,14 @@ import (
 
 	v1alpha1 "github.com/kubewarden/sbomscanner/api/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/messaging"
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
 )
 
 // NodeScanJobFailureHandler handles failures for messages related to node scan jobs.
 type NodeScanJobFailureHandler struct {
-	k8sClient client.Client
-	logger    *slog.Logger
+	k8sClient       client.Client
+	instrumentation *Instrumentation
+	logger          *slog.Logger
 }
 
 // NewNodeScanJobFailureHandler creates a new instance of NodeScanJobFailureHandler.
@@ -27,8 +29,9 @@ func NewNodeScanJobFailureHandler(
 	logger *slog.Logger,
 ) *InstrumentedFailureHandler {
 	return instrumentFailureHandler(instrumentation, "NodeScanJobFailureHandler", &NodeScanJobFailureHandler{
-		k8sClient: k8sClient,
-		logger:    logger.With("handler", "nodescanjob_failure_handler"),
+		k8sClient:       k8sClient,
+		instrumentation: instrumentation,
+		logger:          logger.With("handler", "nodescanjob_failure_handler"),
 	})
 }
 
@@ -45,6 +48,7 @@ func (h *NodeScanJobFailureHandler) HandleFailure(ctx context.Context, message m
 
 	nodeScanJob := &v1alpha1.NodeScanJob{}
 
+	var wasFinished bool
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := h.k8sClient.Get(ctx, client.ObjectKey{
 			Name: nodeBaseMessage.NodeScanJob.Name,
@@ -52,6 +56,7 @@ func (h *NodeScanJobFailureHandler) HandleFailure(ctx context.Context, message m
 			return fmt.Errorf("cannot get NodeScanJob %s: %w", nodeBaseMessage.NodeScanJob.Name, err)
 		}
 
+		wasFinished = telemetry.JobFinished(nodeScanJob)
 		nodeScanJob.MarkFailed(v1alpha1.ReasonScanJobInternalError, errorMessage)
 		return h.k8sClient.Status().Update(ctx, nodeScanJob)
 	})
@@ -61,6 +66,12 @@ func (h *NodeScanJobFailureHandler) HandleFailure(ctx context.Context, message m
 			return nil
 		}
 		return fmt.Errorf("failed to update NodeScanJob %s status to failed: %w", nodeScanJob.Name, err)
+	}
+
+	// Count the failure persisted here; a job that was already finished
+	// was counted by the writer that finished it.
+	if !wasFinished {
+		h.instrumentation.recordNodeScanJobFinished(ctx, nodeScanJob)
 	}
 
 	h.logger.DebugContext(ctx, "NodeScanJob marked as failed",

--- a/internal/handlers/scanjob_failure.go
+++ b/internal/handlers/scanjob_failure.go
@@ -12,12 +12,14 @@ import (
 
 	sbombasticv1alpha1 "github.com/kubewarden/sbomscanner/api/v1alpha1"
 	"github.com/kubewarden/sbomscanner/internal/messaging"
+	"github.com/kubewarden/sbomscanner/internal/telemetry"
 )
 
 // ScanJobFailureHandler handles failures for messages related to scan jobs.
 type ScanJobFailureHandler struct {
-	k8sClient client.Client
-	logger    *slog.Logger
+	k8sClient       client.Client
+	instrumentation *Instrumentation
+	logger          *slog.Logger
 }
 
 // NewScanJobFailureHandler creates a new instance of ScanJobFailureHandler.
@@ -27,8 +29,9 @@ func NewScanJobFailureHandler(
 	logger *slog.Logger,
 ) *InstrumentedFailureHandler {
 	return instrumentFailureHandler(instrumentation, "ScanJobFailureHandler", &ScanJobFailureHandler{
-		k8sClient: k8sClient,
-		logger:    logger.With("handler", "scanjob_failure_handler"),
+		k8sClient:       k8sClient,
+		instrumentation: instrumentation,
+		logger:          logger.With("handler", "scanjob_failure_handler"),
 	})
 }
 
@@ -48,6 +51,7 @@ func (h *ScanJobFailureHandler) HandleFailure(ctx context.Context, message messa
 
 	// It is possible that the controller is slow to set the status condition "Scheduled" to true,
 	// so we might encounter conflicts when setting the status conditions.
+	var wasFinished bool
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := h.k8sClient.Get(ctx, client.ObjectKey{
 			Name:      baseMessage.ScanJob.Name,
@@ -56,6 +60,7 @@ func (h *ScanJobFailureHandler) HandleFailure(ctx context.Context, message messa
 			return fmt.Errorf("cannot get scanjob %s/%s: %w", baseMessage.ScanJob.Namespace, baseMessage.ScanJob.Name, err)
 		}
 
+		wasFinished = telemetry.JobFinished(scanJob)
 		scanJob.MarkFailed(sbombasticv1alpha1.ReasonScanJobInternalError, errorMessage)
 		return h.k8sClient.Status().Update(ctx, scanJob)
 	})
@@ -65,6 +70,12 @@ func (h *ScanJobFailureHandler) HandleFailure(ctx context.Context, message messa
 			return nil
 		}
 		return fmt.Errorf("failed to update ScanJob %s/%s status to failed: %w", scanJob.Namespace, scanJob.Name, err)
+	}
+
+	// Count the failure persisted here; a job that was already finished
+	// was counted by the writer that finished it.
+	if !wasFinished {
+		h.instrumentation.recordScanJobFinished(ctx, scanJob)
 	}
 
 	h.logger.DebugContext(ctx, "ScanJob marked as failed",

--- a/internal/telemetry/jobs.go
+++ b/internal/telemetry/jobs.go
@@ -1,0 +1,121 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/kubewarden/sbomscanner/api"
+	"github.com/kubewarden/sbomscanner/api/v1alpha1"
+)
+
+// Bounded result label values of the job counters.
+const (
+	jobResultComplete = "complete"
+	jobResultFailed   = "failed"
+)
+
+// Bounded source label values of the ScanJob counter.
+const (
+	scanJobSourceRegistry = "registry"
+	scanJobSourceWorkload = "workload"
+)
+
+// JobMetrics counts ScanJobs and NodeScanJobs that reach a terminal state.
+// The counters are incremented at the write sites: every code path that persists
+// a terminal status calls a Record method right after the successful status update.
+// Each completion is counted once, by the process that persists it, without leader
+// election or transition tracking. A crash between the status write and the metric
+// export can lose that count: the counters favor no double counting over durable delivery.
+type JobMetrics struct {
+	scanJobs     metric.Int64Counter
+	nodeScanJobs metric.Int64Counter
+}
+
+// NewJobMetrics creates the job counters and pre-creates the bounded series at zero,
+// so range queries see the first completion: increase() cannot see the birth of a series.
+func NewJobMetrics(meter metric.Meter) (*JobMetrics, error) {
+	scanJobs, err := meter.Int64Counter(
+		"sbomscanner.scanjobs",
+		metric.WithDescription("Number of ScanJobs that reached a terminal state."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating sbomscanner.scanjobs counter: %w", err)
+	}
+
+	nodeScanJobs, err := meter.Int64Counter(
+		"sbomscanner.nodescanjobs",
+		metric.WithDescription("Number of NodeScanJobs that reached a terminal state."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating sbomscanner.nodescanjobs counter: %w", err)
+	}
+
+	for _, result := range []string{jobResultComplete, jobResultFailed} {
+		for _, source := range []string{scanJobSourceRegistry, scanJobSourceWorkload} {
+			scanJobs.Add(context.Background(), 0, metric.WithAttributes(
+				attribute.String("result", result),
+				attribute.String("source", source),
+			))
+		}
+		nodeScanJobs.Add(context.Background(), 0, metric.WithAttributes(
+			attribute.String("result", result),
+		))
+	}
+
+	return &JobMetrics{
+		scanJobs:     scanJobs,
+		nodeScanJobs: nodeScanJobs,
+	}, nil
+}
+
+// JobFinished reports whether the job reached a terminal state.
+// Callers use it to snapshot the state before a terminal status write,
+// so a job finished by an earlier writer is not counted again.
+func JobFinished(job v1alpha1.ConditionedJob) bool {
+	return job.IsComplete() || job.IsFailed()
+}
+
+// RecordScanJobFinished counts one finished ScanJob, labelled with the result and the scan source.
+// It is a no-op when the job is not in a terminal state, so callers can invoke it
+// after every status update of a job that was not terminal before.
+func (m *JobMetrics) RecordScanJobFinished(ctx context.Context, scanJob *v1alpha1.ScanJob) {
+	if !JobFinished(scanJob) {
+		return
+	}
+	m.scanJobs.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("result", jobResult(scanJob)),
+		attribute.String("source", scanJobSource(scanJob)),
+	))
+}
+
+// RecordNodeScanJobFinished counts one finished NodeScanJob, labelled with the result.
+// It is a no-op when the job is not in a terminal state.
+func (m *JobMetrics) RecordNodeScanJobFinished(ctx context.Context, nodeScanJob *v1alpha1.NodeScanJob) {
+	if !JobFinished(nodeScanJob) {
+		return
+	}
+	m.nodeScanJobs.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("result", jobResult(nodeScanJob)),
+	))
+}
+
+// jobResult maps the terminal state to a bounded result label value.
+func jobResult(job v1alpha1.ConditionedJob) string {
+	if job.IsFailed() {
+		return jobResultFailed
+	}
+	return jobResultComplete
+}
+
+// scanJobSource returns the bounded source label of a ScanJob:
+// workload when the job carries the workloadscan label
+// (stamped by the runner for jobs created against workloadscan-managed registries), registry otherwise.
+func scanJobSource(scanJob *v1alpha1.ScanJob) string {
+	if scanJob.GetLabels()[api.LabelWorkloadScanKey] == api.LabelWorkloadScanValue {
+		return scanJobSourceWorkload
+	}
+	return scanJobSourceRegistry
+}

--- a/internal/telemetry/jobs_test.go
+++ b/internal/telemetry/jobs_test.go
@@ -1,0 +1,118 @@
+package telemetry
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/kubewarden/sbomscanner/api"
+	"github.com/kubewarden/sbomscanner/api/v1alpha1"
+)
+
+// newTestJobMetrics builds a JobMetrics backed by an in-memory SDK provider,
+// returning the metric reader used for assertions.
+func newTestJobMetrics(t *testing.T) (*JobMetrics, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = meterProvider.Shutdown(context.Background()) })
+
+	jobs, err := NewJobMetrics(meterProvider.Meter("test"))
+	require.NoError(t, err)
+
+	return jobs, reader
+}
+
+// collectCounter returns the data points of the named counter keyed by their attributes, empty when absent.
+func collectCounter(t *testing.T, reader *sdkmetric.ManualReader, name string, keys ...string) map[string]int64 {
+	t.Helper()
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &resourceMetrics))
+
+	results := map[string]int64{}
+	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+		for _, m := range scopeMetrics.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			for _, point := range sum.DataPoints {
+				parts := make([]string, 0, len(keys))
+				for _, attrKey := range keys {
+					value, _ := point.Attributes.Value(attribute.Key(attrKey))
+					parts = append(parts, value.String())
+				}
+				results[strings.Join(parts, "/")] += point.Value
+			}
+		}
+	}
+	return results
+}
+
+// scanJobInStatus returns a ScanJob in the given lifecycle status.
+func scanJobInStatus(status string) *v1alpha1.ScanJob {
+	scanJob := &v1alpha1.ScanJob{}
+	scanJob.InitializeConditions()
+	switch status {
+	case "in_progress":
+		scanJob.MarkInProgress(v1alpha1.ReasonScanJobImageScanInProgress, "in progress")
+	case "complete":
+		scanJob.MarkComplete(v1alpha1.ReasonScanJobAllImagesScanned, "complete")
+	case "failed":
+		scanJob.MarkFailed(v1alpha1.ReasonScanJobRegistryNotFound, "failed")
+	}
+	return scanJob
+}
+
+// TestRecordScanJobFinished asserts that the series are pre-created at zero,
+// that only terminal jobs are counted, and that the source label follows the workloadscan label.
+func TestRecordScanJobFinished(t *testing.T) {
+	jobs, reader := newTestJobMetrics(t)
+
+	workloadJob := scanJobInStatus("complete")
+	workloadJob.Labels = map[string]string{api.LabelWorkloadScanKey: api.LabelWorkloadScanValue}
+
+	jobs.RecordScanJobFinished(context.Background(), scanJobInStatus("complete"))
+	jobs.RecordScanJobFinished(context.Background(), workloadJob)
+	jobs.RecordScanJobFinished(context.Background(), scanJobInStatus("failed"))
+	jobs.RecordScanJobFinished(context.Background(), scanJobInStatus("in_progress")) // not terminal, not counted
+
+	results := collectCounter(t, reader, "sbomscanner.scanjobs", "result", "source")
+	assert.Equal(t, map[string]int64{
+		"complete/registry": 1,
+		"complete/workload": 1,
+		"failed/registry":   1,
+		"failed/workload":   0, // pre-created at zero, never incremented
+	}, results)
+}
+
+// TestRecordNodeScanJobFinished asserts that the series are pre-created at zero
+// and that only terminal jobs are counted.
+func TestRecordNodeScanJobFinished(t *testing.T) {
+	jobs, reader := newTestJobMetrics(t)
+
+	failedJob := &v1alpha1.NodeScanJob{}
+	failedJob.InitializeConditions()
+	failedJob.MarkFailed(v1alpha1.ReasonScanJobInternalError, "failed")
+
+	pendingJob := &v1alpha1.NodeScanJob{}
+	pendingJob.InitializeConditions()
+
+	jobs.RecordNodeScanJobFinished(context.Background(), failedJob)
+	jobs.RecordNodeScanJobFinished(context.Background(), pendingJob) // not terminal, not counted
+
+	results := collectCounter(t, reader, "sbomscanner.nodescanjobs", "result")
+	assert.Equal(t, map[string]int64{
+		"failed":   1,
+		"complete": 0, // pre-created at zero, never incremented
+	}, results)
+}


### PR DESCRIPTION
## Description

Fixes #1342 and #1343 

The scan-job tiles in the Grafana dashboard were showing incorrect counts. This was caused by two issues:

* Informers were running on every controller replica, so each completed scan was counted once per replica (3 times with the default setup).
* `increase()` does not include the first value of a new metric series, so the first scan after a fresh install showed 0.

The fix moves the counting to the write sites: every code path that persists a terminal ScanJob or NodeScanJob status increments the counter right after the successful status update. Each completion is counted exactly once, by the process that caused it. The counters need no informer, no leader election, and no transition tracking. A shared `telemetry.JobMetrics` helper owns the counters, and both the controller and the worker emit them. The helper also creates the bounded counter series with a value of zero in advance, so the first completion is included in range queries. The dashboard queries aggregate with `sum()` and do not need to change.

The panels have also been renamed from **"scans"** to **"scan jobs"**. The tiles count completed ScanJobs, not the number of images scanned. The image count is available in `sbomscanner.images.scanned`.