### PR TITLE
fix(worker): sanitize FQDN node names in the NATS consumer name

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -162,7 +162,7 @@ func main() {
 			handlers.GenerateNodeSBOMSubject + "." + nodeName: handlers.NewGenerateNodeSBOMHandler(k8sClient, scheme, runDir, targetDir, trivyJavaDBRepository, publisher, installationNamespace, logger),
 			handlers.ScanNodeSBOMSubject + "." + nodeName:     handlers.NewNodeScanSBOMHandler(k8sClient, scheme, runDir, trivyDBRepository, trivyJavaDBRepository, logger),
 		}
-		durableName = "worker-node-" + nodeName
+		durableName = sanitizeNodeSubscriberName(nodeName)
 	default:
 		logger.Error("Invalid scanning mode", "mode", mode)
 		os.Exit(1)

--- a/cmd/worker/nats.go
+++ b/cmd/worker/nats.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// sanitizeNodeSubscriberName returns the durable consumer name of the node worker
+// for the given node name.
+// It assumes that nodeName is a valid Kubernetes node name (RFC 1123 DNS subdomain):
+// lowercase alphanumerics, '-', and '.', at most 253 characters.
+// NATS forbids '.' in consumer names, so dots are replaced with '_'.
+// A node name cannot contain '_', so two node names can never map to the same result.
+// Characters that cannot appear in a node name are removed defensively.
+// A name over the 255-character NATS limit is truncated
+// and gets a hash of the original node name as suffix to stay collision-resistant.
+func sanitizeNodeSubscriberName(nodeName string) string {
+	const maxLen = 255
+
+	sanitized := strings.Map(func(r rune) rune {
+		switch {
+		case r == '.':
+			return '_'
+		case r == '-' || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			return r
+		default:
+			return -1
+		}
+	}, nodeName)
+
+	name := "worker-node-" + sanitized
+	if len(name) > maxLen {
+		hash := sha256.Sum256([]byte(nodeName))
+		suffix := "-" + hex.EncodeToString(hash[:16])
+		name = name[:maxLen-len(suffix)] + suffix
+	}
+
+	return name
+}

--- a/cmd/worker/nats_test.go
+++ b/cmd/worker/nats_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeNodeSubscriberName(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodeName string
+		expected string
+	}{
+		{
+			name:     "plain node name is unchanged",
+			nodeName: "pippo",
+			expected: "worker-node-pippo",
+		},
+		{
+			name:     "FQDN dots are replaced with underscores",
+			nodeName: "turingpi-node1.localdomain",
+			expected: "worker-node-turingpi-node1_localdomain",
+		},
+		{
+			name:     "dot and dash node names do not collide",
+			nodeName: "node-1.local",
+			expected: "worker-node-node-1_local",
+		},
+		{
+			name:     "characters that are invalid in node names are removed",
+			nodeName: "node*1 .local",
+			expected: "worker-node-node1_local",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, sanitizeNodeSubscriberName(test.nodeName))
+		})
+	}
+}
+
+func TestSanitizeNodeSubscriberName_Overlong(t *testing.T) {
+	// The longest possible node name (253 chars) plus the "worker-node-" prefix
+	// exceeds the 255-char limit and must be truncated with a hash suffix.
+	long := strings.Repeat("a", 252)
+	sanitizedA := sanitizeNodeSubscriberName(long + "b")
+	sanitizedB := sanitizeNodeSubscriberName(long + "c")
+
+	require.Len(t, sanitizedA, 255)
+	require.Len(t, sanitizedB, 255)
+	require.NotEqual(t, sanitizedA, sanitizedB, "node names differing past the truncation point must stay distinct")
+	require.Equal(t, sanitizedA, sanitizeNodeSubscriberName(long+"b"), "sanitization must be deterministic")
+}


### PR DESCRIPTION
Fixes #1353

Santize FQDN node names in the NATS consumer name