### PR TITLE
feat(sbomscannerdb): use sqlite instead of in-memory parsed feeds 

### DIFF
--- a/charts/sbomscanner/questions.yaml
+++ b/charts/sbomscanner/questions.yaml
@@ -105,7 +105,7 @@ questions:
     default: ""
     group: Worker
     description: |
-      OCI reference (tag) of the sbomscanner vulnerability database (KEV, EPSS, …). Empty disables the enrichment of vulnerability reports.
+      OCI repository of the sbomscanner vulnerability database (KEV, EPSS, …). Empty disables the enrichment of vulnerability reports.
 
   ###############################################################################
   # Storage

--- a/charts/sbomscanner/tests/worker/daemonset_test.yaml
+++ b/charts/sbomscanner/tests/worker/daemonset_test.yaml
@@ -19,8 +19,8 @@ tests:
   - it: "should pass the sbomscanner DB repository to the worker when set"
     set:
       worker:
-        sbomscannerDBRepository: ghcr.io/example/sbomscannerdb:1
+        sbomscannerDBRepository: ghcr.io/example/sbomscannerdb
     asserts:
       - contains:
           path: "spec.template.spec.containers[0].args"
-          content: "-sbomscanner-db-repository=ghcr.io/example/sbomscannerdb:1"
+          content: "-sbomscanner-db-repository=ghcr.io/example/sbomscannerdb"

--- a/charts/sbomscanner/tests/worker/deployment_test.yaml
+++ b/charts/sbomscanner/tests/worker/deployment_test.yaml
@@ -61,8 +61,8 @@ tests:
   - it: "should pass the sbomscanner DB repository to the worker when set"
     set:
       worker:
-        sbomscannerDBRepository: ghcr.io/example/sbomscannerdb:1
+        sbomscannerDBRepository: ghcr.io/example/sbomscannerdb
     asserts:
       - contains:
           path: "spec.template.spec.containers[0].args"
-          content: "-sbomscanner-db-repository=ghcr.io/example/sbomscannerdb:1"
+          content: "-sbomscanner-db-repository=ghcr.io/example/sbomscannerdb"

--- a/charts/sbomscanner/values.yaml
+++ b/charts/sbomscanner/values.yaml
@@ -108,7 +108,7 @@ worker:
       memory: 300Mi
   trivyDBRepository: public.ecr.aws/aquasecurity/trivy-db
   trivyJavaDBRepository: public.ecr.aws/aquasecurity/trivy-java-db
-  # OCI reference (tag) of the sbomscanner vulnerability database (KEV, EPSS, …).
+  # OCI repository of the sbomscanner vulnerability database (KEV, EPSS, …).
   # Empty disables the enrichment of vulnerability reports.
   sbomscannerDBRepository: ""
 

--- a/cmd/sbomscannerdb/cli.go
+++ b/cmd/sbomscannerdb/cli.go
@@ -51,7 +51,7 @@ func rootCommand() *cli.Command {
 func buildCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "build",
-		Usage: "Download KEV/EPSS and build the DB artifact into the local store",
+		Usage: "Download KEV/EPSS, build a SQLite database per feed, and pack them as the DB artifact in the local store",
 		Description: "The build time defaults to the current wall-clock time. Set the\n" +
 			"SOURCE_DATE_EPOCH environment variable (Unix seconds) to pin it,\n" +
 			"making the artifact reproducible; it drives the created and\n" +
@@ -68,7 +68,7 @@ func buildCommand() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:  "data-dir",
-				Usage: "directory with the feed files to pack; skips the download",
+				Usage: "directory with the upstream feed files (known_exploited_vulnerabilities.json, epss_scores.csv); skips the download",
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/cmd/sbomscannerdb/cli_test.go
+++ b/cmd/sbomscannerdb/cli_test.go
@@ -66,8 +66,8 @@ func TestCLI_BuildFailsOnMissingDataFile(t *testing.T) {
 func TestCLI_BuildFailsOnMalformedDataFile(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 	dataDir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dataDir, datafeed.KEVFileName), []byte("not json"), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(dataDir, datafeed.EPSSFileName), []byte("not csv"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, datafeed.KEVSourceFileName), []byte("not json"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, datafeed.EPSSSourceFileName), []byte("not csv"), 0o600))
 
 	_, err := runCLI(t, "build", "--data-dir", dataDir, "registry.example.com/db:latest")
 
@@ -75,6 +75,16 @@ func TestCLI_BuildFailsOnMalformedDataFile(t *testing.T) {
 	require.ErrorAs(t, err, &exitCoder)
 	assert.Equal(t, 1, exitCoder.ExitCode())
 	assert.Contains(t, err.Error(), "validate KEV")
+}
+
+func TestCLI_BuildFromDataDir(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	_, err := runCLI(t, "build", "--data-dir", filepath.Join("..", "..", "test", "fixtures", "sbomscannerdb"), "registry.example.com/db:latest")
+
+	require.NoError(t, err)
+	// The fixture directory is read, never written.
+	assert.NoFileExists(t, filepath.Join("..", "..", "test", "fixtures", "sbomscannerdb", datafeed.KEVDBFileName))
 }
 
 func TestCLI_ExportRequiresReference(t *testing.T) {

--- a/cmd/sbomscannerdb/commands.go
+++ b/cmd/sbomscannerdb/commands.go
@@ -13,34 +13,36 @@ import (
 	"github.com/kubewarden/sbomscanner/internal/sbomscannerdb/oci"
 )
 
-// runBuild packs the data feeds as an OCI artifact and tags it in the local store.
-// The feeds are downloaded into a temp dir, or read from dataDir when it is set.
-// nextUpdateInterval is the shortest cadence among the bundled feeds; it sets
-// how far ahead the artifact's nextUpdate annotation points from build time.
+// runBuild builds a SQLite database per feed, packs them as an OCI artifact, and tags it in the local store.
+// The upstream feed files are downloaded, or read from dataDir when it is set.
+// nextUpdateInterval is the shortest cadence among the feeds. It sets how far ahead nextUpdate points.
 func runBuild(ctx context.Context, ref, dataDir string, nextUpdateInterval time.Duration, logger *slog.Logger) error {
-	download := dataDir == ""
-	if download {
-		tempDir, err := os.MkdirTemp("", "sbomscannerdb-data-*")
-		if err != nil {
-			return fmt.Errorf("create temp data dir: %w", err)
-		}
-		defer os.RemoveAll(tempDir)
-		dataDir = tempDir
+	workDir, err := os.MkdirTemp("", "sbomscannerdb-build-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(workDir)
+
+	srcDir := dataDir
+	if srcDir == "" {
+		srcDir = workDir
 	}
 
 	var layers []oci.Layer
 	for _, source := range datafeed.AllSources(datafeed.NewHTTPDownloader(), logger) {
-		if download {
-			if err := source.Download(ctx, dataDir); err != nil {
+		if dataDir == "" {
+			if err := source.Download(ctx, srcDir); err != nil {
 				return fmt.Errorf("download %s: %w", source.Name(), err)
 			}
-		} else if err := source.Validate(dataDir); err != nil {
-			return fmt.Errorf("%s in %s: %w", source.Name(), dataDir, err)
+		}
+		fileName, err := source.BuildSQLite(ctx, srcDir, workDir)
+		if err != nil {
+			return fmt.Errorf("%s: %w", source.Name(), err)
 		}
 		layers = append(layers, oci.Layer{
 			Name:      source.Name(),
-			FileName:  source.FileName(),
-			MediaType: oci.DataLayerMediaType(source.Name(), source.Format()),
+			FileName:  fileName,
+			MediaType: oci.DataLayerMediaType(source.Name()),
 		})
 	}
 
@@ -49,7 +51,7 @@ func runBuild(ctx context.Context, ref, dataDir string, nextUpdateInterval time.
 		return fmt.Errorf("open local store: %w", err)
 	}
 	artifact, err := oci.NewBuilder(store, logger, os.Getenv(oci.SourceDateEpochEnv)).
-		Build(ctx, ref, dataDir, layers, nextUpdateInterval)
+		Build(ctx, ref, workDir, layers, nextUpdateInterval)
 	if err != nil {
 		return fmt.Errorf("build artifact: %w", err)
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -56,7 +56,7 @@ func main() {
 	flag.StringVar(&trivyDBRepository, "trivy-db-repository", "public.ecr.aws/aquasecurity/trivy-db", "OCI repository to retrieve trivy-db.")
 	flag.StringVar(&trivyJavaDBRepository, "trivy-java-db-repository", "public.ecr.aws/aquasecurity/trivy-java-db", "OCI repository to retrieve trivy-java-db.")
 	flag.StringVar(&installationNamespace, "installation-namespace", "sbomscanner", "The namespace where sbomscanner is installed.")
-	flag.StringVar(&sbomscannerDBRepository, "sbomscanner-db-repository", "", "OCI reference (tag) of the sbomscanner vulnerability database (KEV, EPSS, …). Empty disables the database.")
+	flag.StringVar(&sbomscannerDBRepository, "sbomscanner-db-repository", "", "OCI repository of the sbomscanner vulnerability database (KEV, EPSS, …). Empty disables the database.")
 	flag.BoolVar(&init, "init", false, "Run initialization tasks and exit.")
 	flag.StringVar(&logLevel, "log-level", slog.LevelInfo.String(), "Log level.")
 	flag.StringVar(&mode, "mode", "registry", "Mode of operation ('registry' or 'node').")

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -154,7 +154,7 @@ func main() {
 
 	var sbomscannerDB *sbomscannerdb.DB
 	if sbomscannerDBRepository != "" {
-		sbomscannerDB = sbomscannerdb.New(sbomscannerDBRepository, runDir, oci.Config{}, logger)
+		sbomscannerDB = sbomscannerdb.Open(sbomscannerDBRepository, runDir, oci.Config{}, logger)
 	}
 
 	var scanMode messaging.HandlerRegistry
@@ -207,6 +207,10 @@ func main() {
 	logger.Debug("Shutting down health server")
 	if err := healthServer.Close(); err != nil {
 		logger.Error("Error shutting down health check server", "error", err)
+		os.Exit(1)
+	}
+	if err := sbomscannerDB.Close(); err != nil {
+		logger.Error("Error closing the sbomscanner database", "error", err)
 		os.Exit(1)
 	}
 }

--- a/docs/rfc/0010_enrichment_vulnerability_database.md
+++ b/docs/rfc/0010_enrichment_vulnerability_database.md
@@ -18,7 +18,8 @@ Define the architecture for the SBOMScanner enrichment vulnerability database: a
 distribute auxiliary data (e.g. KEV, EPSS) to SBOMScanner workers by packaging it as an
 OCI artifact. A dedicated CLI builds and pushes the artifact, a CI pipeline rebuilds and
 publishes it on a fixed schedule, and the worker component pulls it from a remote registry
-and keeps a local copy up to date. The design is data-type agnostic (JSON, CSV, etc.) and
+and keeps a local copy up to date. Each feed is converted into a SQLite database at build
+time, so the worker queries it instead of parsing the upstream format. The design is
 optimized for deduplication and low network overhead.
 
 # Motivation
@@ -109,8 +110,8 @@ system has three moving parts:
 
 ## OCI artifact structure
 
-Each data file becomes its **own layer** in the OCI artifact. A layer contains exactly one
-file. This layout is deliberate and gives us two properties:
+Each feed becomes its **own layer** in the OCI artifact. A layer contains exactly one
+SQLite database file. This layout is deliberate and gives us two properties:
 
 * **Deduplication**: layers are content-addressed by digest. If a file is unchanged between
   two builds, its layer digest is identical and the registry (and the worker) reuse the
@@ -118,11 +119,19 @@ file. This layout is deliberate and gives us two properties:
 * **Minimal transfer**: when the worker pulls an updated artifact, only the layers whose
   digests changed are downloaded. Unchanged files cost nothing on the wire.
 
-Before being added to the artifact, every data file is **packed and compressed as `tar.gz`**,
-independently of its input format. Whether the source is JSON, CSV, or anything else, the file
-is first archived and gzipped (e.g. `kev.json` becomes `kev.tar.gz`) and that `tar.gz` is what
-becomes the layer blob. This gives a uniform packaging step for all data types and reduces the
-on-the-wire and at-rest size of each layer.
+The build step downloads each upstream feed in its native format (JSON for KEV, CSV for
+EPSS), validates it, and **builds a SQLite database** from it. Every feed database has the
+same single table: one row per CVE, with the CVE ID as the key and the feed's data for that
+CVE as a JSON entry. The worker never sees the upstream format; it looks up a CVE and decodes
+the entry. The KEV entry is stored as the JSON object CISA published, so a new upstream field
+lands in the artifact without a build change. The build is reproducible: rows are inserted in
+a fixed order into a fresh file that is then compacted, so the same feed content always yields
+the same bytes and the same layer digest.
+
+Before being added to the artifact, every database file is **packed and compressed as
+`tar.gz`** (e.g. `kev.sqlite` becomes `kev.tar.gz`) and that `tar.gz` is what becomes the
+layer blob. This gives a uniform packaging step and reduces the on-the-wire and at-rest size
+of each layer.
 
 Using `tar` (and not just `gzip`) is a deliberate design decision: a database is not necessarily
 a single file. When a data source is made up of multiple files, `tar` lets us bundle them into
@@ -136,19 +145,18 @@ a metadata change alone would alter the digest and defeat the content-addressed 
 the OCI format gives us. With it, an unchanged data file yields the same digest build after
 build, so the registry and workers reuse the existing blob instead of re-transferring it.
 
-Each layer carries a media type that records the file's format so the worker knows how to
-handle it, e.g.:
+Each layer carries a media type that names the feed, the file format, and the packaging, e.g.:
 
 ```
-application/vnd.sbomscanner.db.file.v1.json+gzip   # KEV feed  (kev.json  -> kev.tar.gz)
-application/vnd.sbomscanner.db.file.v1.csv+gzip    # EPSS feed (epss.csv -> epss.tar.gz)
+application/vnd.sbomscanner.db.kev.v1.sqlite+tar+gzip    # KEV  (kev.sqlite  -> kev.tar.gz)
+application/vnd.sbomscanner.db.epss.v1.sqlite+tar+gzip   # EPSS (epss.sqlite -> epss.tar.gz)
 ```
 
-The media type still records the underlying file format so the worker knows how to parse the
-file after decompressing the layer; the `+gzip` suffix reflects the `tar.gz` packaging.
+The `+tar+gzip` suffix reflects the `tar.gz` packaging, the same way `application/vnd.oci.image.layer.v1.tar+gzip` does.
 
-The artifact is **format-agnostic**: adding a new data type is a matter of adding a file and
-declaring its media type; no structural change to the artifact is required.
+The artifact layout is the same for every feed: one file per layer, each with its own media type.
+Adding a feed needs no change to the layout.
+It needs a converter on the build side and a lookup on the worker side.
 
 Adding a new file to the artifact is **backward-compatible**: on the next pull the new layer
 simply appears in the worker's cache directory, but the worker just ignores files unknown to it.
@@ -315,9 +323,9 @@ New code in the worker to:
 * On each incoming scan, read `nextUpdate` from the locally cached manifest and pull a new
   artifact only when `now >= nextUpdate`; otherwise use the current local content unchanged.
   A failed pull fails the scan.
-* Expose an internal lookup interface over the locally stored data for use during scans.
-* For each new data file, add a new adapter implementation that knows how to parse the file
-  format (e.g. KEV adapter, EPSS adapter) and provide a uniform lookup API to the worker.
+* Open the exported databases read-only and query them per CVE during scans. The worker keeps
+  no feed data in memory, so its footprint does not grow with the feeds.
+* For each new feed, add a converter on the build side and a query on the worker side.
 
 # Drawbacks
 
@@ -356,10 +364,6 @@ Why should we **not** do this?
 
 [future]: #future-considerations
 
-* **SQLite layers.** Convert each data file into a per-file SQLite database stored in the OCI
-  artifact. The worker would then query the database directly rather than parsing raw JSON/CSV,
-  improving lookup performance and reducing parsing complexity, while preserving the
-  one-file-per-layer deduplication model.
 * **Per-database update cadence.** Allow each data source to declare its own update cadence, so that
   the worker can pull only when a given database is expected to have changed, rather than
   rebuilding the entire artifact on the shortest cadence. This would require a more complex

--- a/docs/rfc/0010_enrichment_vulnerability_database.md
+++ b/docs/rfc/0010_enrichment_vulnerability_database.md
@@ -195,7 +195,8 @@ The tag of the artifact is the **schema version** of the database, not a release
 Every rebuild pushes to the **same tag** in the registry
 (e.g. `registry.example.com/sbomscanner/sbomscannerdb:1`). SBOMScanner always pulls that one tag,
 so there is no version negotiation, no version pinning, and no cleanup of stale versions to
-manage. Freshness is expressed entirely through the annotations and layer digests, not
+manage. The worker is configured with the repository only and appends the tag itself,
+the same way Trivy appends `:2` to `--db-repository`. Freshness is expressed entirely through the annotations and layer digests, not
 through tags.
 
 The schema version changes only when the content of the artifact changes in a way that an

--- a/hack/generate_fixtures.go
+++ b/hack/generate_fixtures.go
@@ -63,7 +63,7 @@ func main() {
 		log.Fatalf("failed to create cache dir: %v", err)
 	}
 	defer os.RemoveAll(cacheDir)
-	db := sbomscannerdb.New(testSBOMScannerDBRepository, cacheDir, oci.Config{}, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	db := sbomscannerdb.Open(testSBOMScannerDBRepository, cacheDir, oci.Config{}, slog.New(slog.NewTextHandler(os.Stderr, nil)))
 
 	for _, file := range files {
 		if err := generateReport(context.Background(), db, cacheDir, file); err != nil {
@@ -217,7 +217,10 @@ func generateReport(ctx context.Context, db *sbomscannerdb.DB, cacheDir, spdxFil
 	for i := range results {
 		for j := range results[i].Vulnerabilities {
 			vuln := &results[i].Vulnerabilities[j]
-			record := db.Lookup(vuln.CVE)
+			record, err := db.Lookup(ctx, vuln.CVE)
+			if err != nil {
+				return fmt.Errorf("failed to look up %s: %w", vuln.CVE, err)
+			}
 			vuln.KEV = record.KEV
 			vuln.EPSS = record.EPSS
 		}

--- a/hack/generate_fixtures.go
+++ b/hack/generate_fixtures.go
@@ -27,7 +27,7 @@ import (
 const (
 	testTrivyDBRepository       = "ghcr.io/kubewarden/sbomscanner/test-assets/trivy-db:2"
 	testTrivyJavaDBRepository   = "ghcr.io/kubewarden/sbomscanner/test-assets/trivy-java-db:1"
-	testSBOMScannerDBRepository = "ghcr.io/kubewarden/sbomscanner/test-assets/sbomscannerdb:1"
+	testSBOMScannerDBRepository = "ghcr.io/kubewarden/sbomscanner/test-assets/sbomscannerdb"
 )
 
 func main() {

--- a/internal/handlers/scan_sbom_helpers.go
+++ b/internal/handlers/scan_sbom_helpers.go
@@ -172,7 +172,10 @@ func (b *scanSBOMBase) enrichResults(ctx context.Context, results []storagev1alp
 		vulns := results[i].Vulnerabilities
 		for j := range vulns {
 			vuln := &vulns[j]
-			record := b.sbomscannerDB.Lookup(vuln.CVE)
+			record, err := b.sbomscannerDB.Lookup(ctx, vuln.CVE)
+			if err != nil {
+				return fmt.Errorf("failed to look up %s in sbomscanner DB: %w", vuln.CVE, err)
+			}
 			vuln.KEV = record.KEV
 			vuln.EPSS = record.EPSS
 		}

--- a/internal/handlers/scan_sbom_helpers_test.go
+++ b/internal/handlers/scan_sbom_helpers_test.go
@@ -22,7 +22,8 @@ import (
 // testDBRef uses a reserved host, so every registry contact fails fast.
 const testDBRef = "registry.invalid/kubewarden/sbomscannerdb:latest"
 
-// seedFeeds writes a KEV catalog and an EPSS feed with CVE-2021-44228 into dir.
+// seedFeeds writes the KEV and EPSS databases with CVE-2021-44228 into dir,
+// converted from upstream feeds the same way build does.
 func seedFeeds(t *testing.T, dir string) {
 	t.Helper()
 	kev, err := json.Marshal(datafeed.KEVCatalog{
@@ -33,13 +34,19 @@ func seedFeeds(t *testing.T, dir string) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.KEVFileName), kev, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.KEVSourceFileName), kev, 0o600))
 
 	score := datafeed.EPSSScore{CVE: "CVE-2021-44228", EPSS: 0.97, Percentile: 0.999}
 	epss := "#model_version:v1,score_date:" + scoreDate().Format(time.RFC3339) + "\n" +
 		"cve,epss,percentile\n" +
 		fmt.Sprintf("%s,%g,%g\n", score.CVE, score.EPSS, score.Percentile)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.EPSSFileName), []byte(epss), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.EPSSSourceFileName), []byte(epss), 0o600))
+
+	logger := slog.New(slog.DiscardHandler)
+	for _, source := range datafeed.AllSources(datafeed.NewHTTPDownloader(), logger) {
+		_, err := source.BuildSQLite(context.Background(), dir, dir)
+		require.NoError(t, err)
+	}
 }
 
 // scoreDate is the score_date of the seeded EPSS feed.
@@ -55,15 +62,15 @@ func seededDB(t *testing.T) *sbomscannerdb.DB {
 	dataDir := t.TempDir()
 	seedFeeds(t, dataDir)
 	layers := []oci.Layer{
-		{Name: "kev", FileName: datafeed.KEVFileName, MediaType: oci.DataLayerMediaType("kev", "json")},
-		{Name: "epss", FileName: datafeed.EPSSFileName, MediaType: oci.DataLayerMediaType("epss", "csv")},
+		{Name: "kev", FileName: datafeed.KEVDBFileName, MediaType: oci.DataLayerMediaType("kev")},
+		{Name: "epss", FileName: datafeed.EPSSDBFileName, MediaType: oci.DataLayerMediaType("epss")},
 	}
 
 	runDir := t.TempDir()
 	localStore := oci.NewStore(filepath.Join(runDir, "sbomscannerdb", "oci"), logger)
 	_, err := oci.NewBuilder(localStore, logger, "").Build(context.Background(), testDBRef, dataDir, layers, 24*time.Hour)
 	require.NoError(t, err)
-	return sbomscannerdb.New(testDBRef, runDir, oci.Config{}, logger)
+	return sbomscannerdb.Open(testDBRef, runDir, oci.Config{}, logger)
 }
 
 func TestEnrichResults_PopulatesKEVAndEPSS(t *testing.T) {
@@ -104,7 +111,7 @@ func TestEnrichResults_NilStoreLeavesResultsUnchanged(t *testing.T) {
 func TestEnrichResults_FailsWhenDBCannotUpdate(t *testing.T) {
 	// An empty run dir and an unreachable registry, so the DB cannot be updated.
 	base := &scanSBOMBase{
-		sbomscannerDB: sbomscannerdb.New(testDBRef, t.TempDir(), oci.Config{}, slog.New(slog.DiscardHandler)),
+		sbomscannerDB: sbomscannerdb.Open(testDBRef, t.TempDir(), oci.Config{}, slog.New(slog.DiscardHandler)),
 		logger:        slog.New(slog.DiscardHandler),
 	}
 	results := []storagev1alpha1.Result{

--- a/internal/handlers/scan_sbom_helpers_test.go
+++ b/internal/handlers/scan_sbom_helpers_test.go
@@ -19,8 +19,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// testDBRef uses a reserved host, so every registry contact fails fast.
-const testDBRef = "registry.invalid/kubewarden/sbomscannerdb:latest"
+// testDBRepository uses a reserved host, so every registry contact fails fast.
+const testDBRepository = "registry.invalid/kubewarden/sbomscannerdb"
+
+// testDBRef is the reference that sbomscannerdb.Open builds from testDBRepository.
+const testDBRef = testDBRepository + ":1"
 
 // seedFeeds writes the KEV and EPSS databases with CVE-2021-44228 into dir,
 // converted from upstream feeds the same way build does.
@@ -70,7 +73,7 @@ func seededDB(t *testing.T) *sbomscannerdb.DB {
 	localStore := oci.NewStore(filepath.Join(runDir, "sbomscannerdb", "oci"), logger)
 	_, err := oci.NewBuilder(localStore, logger, "").Build(context.Background(), testDBRef, dataDir, layers, 24*time.Hour)
 	require.NoError(t, err)
-	return sbomscannerdb.Open(testDBRef, runDir, oci.Config{}, logger)
+	return sbomscannerdb.Open(testDBRepository, runDir, oci.Config{}, logger)
 }
 
 func TestEnrichResults_PopulatesKEVAndEPSS(t *testing.T) {
@@ -111,7 +114,7 @@ func TestEnrichResults_NilStoreLeavesResultsUnchanged(t *testing.T) {
 func TestEnrichResults_FailsWhenDBCannotUpdate(t *testing.T) {
 	// An empty run dir and an unreachable registry, so the DB cannot be updated.
 	base := &scanSBOMBase{
-		sbomscannerDB: sbomscannerdb.Open(testDBRef, t.TempDir(), oci.Config{}, slog.New(slog.DiscardHandler)),
+		sbomscannerDB: sbomscannerdb.Open(testDBRepository, t.TempDir(), oci.Config{}, slog.New(slog.DiscardHandler)),
 		logger:        slog.New(slog.DiscardHandler),
 	}
 	results := []storagev1alpha1.Result{

--- a/internal/handlers/utils_test.go
+++ b/internal/handlers/utils_test.go
@@ -24,7 +24,7 @@ import (
 const (
 	testTrivyDBRepository       = "ghcr.io/kubewarden/sbomscanner/test-assets/trivy-db:2"
 	testTrivyJavaDBRepository   = "ghcr.io/kubewarden/sbomscanner/test-assets/trivy-java-db:1"
-	testSBOMScannerDBRepository = "ghcr.io/kubewarden/sbomscanner/test-assets/sbomscannerdb:1"
+	testSBOMScannerDBRepository = "ghcr.io/kubewarden/sbomscanner/test-assets/sbomscannerdb"
 )
 
 // newTestSBOMScannerDB returns a DB that pulls the test asset into runDir.

--- a/internal/handlers/utils_test.go
+++ b/internal/handlers/utils_test.go
@@ -30,7 +30,7 @@ const (
 // newTestSBOMScannerDB returns a DB that pulls the test asset into runDir.
 // It does not use slog.Default, which trivy replaces with a handler that is not thread safe.
 func newTestSBOMScannerDB(runDir string) *sbomscannerdb.DB {
-	return sbomscannerdb.New(testSBOMScannerDBRepository, runDir, oci.Config{}, slog.New(slog.DiscardHandler))
+	return sbomscannerdb.Open(testSBOMScannerDBRepository, runDir, oci.Config{}, slog.New(slog.DiscardHandler))
 }
 
 const (

--- a/internal/sbomscannerdb/datafeed/epss.go
+++ b/internal/sbomscannerdb/datafeed/epss.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,8 +17,11 @@ import (
 	"time"
 )
 
-// EPSSFileName is the file name of the EPSS scores in the destination directory.
-const EPSSFileName = "epss_scores.csv"
+// EPSSSourceFileName is the file name of the EPSS scores as downloaded from FIRST.
+const EPSSSourceFileName = "epss_scores.csv"
+
+// EPSSDBFileName is the file name of the EPSS database built from the scores.
+const EPSSDBFileName = "epss.sqlite"
 
 // defaultEPSSURL is the daily EPSS bulk feed (gzipped CSV).
 const defaultEPSSURL = "https://epss.empiricalsecurity.com/epss_scores-current.csv.gz"
@@ -39,6 +43,13 @@ type EPSSScore struct {
 	CVE        string
 	EPSS       float64
 	Percentile float64
+}
+
+// EPSSEntry is the JSON stored per CVE in the EPSS database.
+type EPSSEntry struct {
+	EPSS       float64   `json:"epss"`
+	Percentile float64   `json:"percentile"`
+	Date       time.Time `json:"date"`
 }
 
 // ParseEPSSScores parses and sanity-checks an EPSS bulk feed CSV:
@@ -149,37 +160,37 @@ func NewEPSSDownloader(httpDownloader *HTTPDownloader, logger *slog.Logger) *EPS
 // Name is the short feed id.
 func (d *EPSSDownloader) Name() string { return "epss" }
 
-// FileName is the EPSS scores' file name within the data directory.
-func (d *EPSSDownloader) FileName() string { return EPSSFileName }
-
-// Format is the EPSS scores' file format.
-func (d *EPSSDownloader) Format() string { return "csv" }
-
-// Download fetches the EPSS scores (gzipped CSV, decompressed on the fly)
-// into dir/EPSSFileName and validates that it parses as a usable feed.
+// Download fetches the EPSS scores (gzipped CSV, decompressed on the fly) into dir.
 func (d *EPSSDownloader) Download(ctx context.Context, dir string) error {
-	dst := filepath.Join(dir, EPSSFileName)
 	d.logger.InfoContext(ctx, "downloading EPSS scores", "url", d.url)
-	size, err := d.http.Download(ctx, d.url, dst)
+	size, err := d.http.Download(ctx, d.url, filepath.Join(dir, EPSSSourceFileName))
 	if err != nil {
 		return fmt.Errorf("download EPSS: %w", err)
 	}
-
-	scores, err := parseEPSSFile(dst)
-	if err != nil {
-		return fmt.Errorf("validate EPSS: %w", err)
-	}
-
-	d.logger.InfoContext(ctx, "downloaded EPSS scores", "file", EPSSFileName, "bytes", size, "rows", len(scores.Scores), "modelVersion", scores.ModelVersion)
+	d.logger.InfoContext(ctx, "downloaded EPSS scores", "bytes", size)
 	return nil
 }
 
-// Validate parses dir/EPSSFileName as an EPSS feed.
-func (d *EPSSDownloader) Validate(dir string) error {
-	if _, err := parseEPSSFile(filepath.Join(dir, EPSSFileName)); err != nil {
-		return fmt.Errorf("validate EPSS: %w", err)
+// BuildSQLite parses srcDir/EPSSSourceFileName and writes dstDir/EPSSDBFileName.
+// Each entry carries the score, the percentile, and the feed's score_date.
+func (d *EPSSDownloader) BuildSQLite(ctx context.Context, srcDir, dstDir string) (string, error) {
+	scores, err := parseEPSSFile(filepath.Join(srcDir, EPSSSourceFileName))
+	if err != nil {
+		return "", fmt.Errorf("validate EPSS: %w", err)
 	}
-	return nil
+	entries := make([]Entry, 0, len(scores.Scores))
+	for _, score := range scores.Scores {
+		data, err := json.Marshal(EPSSEntry{EPSS: score.EPSS, Percentile: score.Percentile, Date: scores.ScoreDate})
+		if err != nil {
+			return "", fmt.Errorf("encode EPSS entry %s: %w", score.CVE, err)
+		}
+		entries = append(entries, Entry{CVE: score.CVE, JSON: data})
+	}
+	if err := writeDatabase(ctx, filepath.Join(dstDir, EPSSDBFileName), entries); err != nil {
+		return "", fmt.Errorf("build EPSS database: %w", err)
+	}
+	d.logger.InfoContext(ctx, "built EPSS database", "file", EPSSDBFileName, "rows", len(entries), "modelVersion", scores.ModelVersion)
+	return EPSSDBFileName, nil
 }
 
 // parseEPSSFile opens the file at path and parses it as an EPSS feed.

--- a/internal/sbomscannerdb/datafeed/epss_test.go
+++ b/internal/sbomscannerdb/datafeed/epss_test.go
@@ -24,28 +24,22 @@ func TestEPSSDownloader_Download(t *testing.T) {
 	d.url = srv.URL + "/epss_scores.csv.gz"
 	require.NoError(t, d.Download(context.Background(), dir))
 
-	// The gzipped fixture must land decompressed under the plain CSV name.
-	file, err := os.Open(filepath.Join(dir, EPSSFileName))
+	// Download decompresses the CSV; BuildSQLite turns it into the database.
+	dbDir := t.TempDir()
+	_, err := d.BuildSQLite(context.Background(), dir, dbDir)
 	require.NoError(t, err)
-	defer file.Close()
 
-	scores, err := ParseEPSSScores(file)
-	require.NoError(t, err)
-	assert.Equal(t, "v2026.06.15", scores.ModelVersion)
-	assert.Equal(t, time.Date(2026, time.July, 12, 12, 0, 0, 0, time.UTC), scores.ScoreDate)
-	require.Len(t, scores.Scores, 1)
-	assert.Equal(t, EPSSScore{CVE: "CVE-2021-44228", EPSS: 0.97565, Percentile: 0.99992}, scores.Scores[0])
+	var entry EPSSEntry
+	lookupJSON(t, filepath.Join(dbDir, EPSSDBFileName), "CVE-2021-44228", &entry)
+	assert.Equal(t, EPSSEntry{EPSS: 0.97565, Percentile: 0.99992, Date: time.Date(2026, time.July, 12, 12, 0, 0, 0, time.UTC)}, entry)
 }
 
-func TestEPSSDownloader_DownloadFailsOnInvalidPayload(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("<html><body>Service temporarily unavailable</body></html>"))
-	}))
-	t.Cleanup(srv.Close)
+func TestEPSSDownloader_BuildSQLiteFailsOnInvalidPayload(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EPSSSourceFileName), []byte("<html>error</html>"), 0o600))
 
 	d := NewEPSSDownloader(NewHTTPDownloader(), slog.New(slog.DiscardHandler))
-	d.url = srv.URL + "/epss_scores-current.csv.gz"
-	err := d.Download(context.Background(), t.TempDir())
+	_, err := d.BuildSQLite(context.Background(), dir, t.TempDir())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "validate EPSS")
 }

--- a/internal/sbomscannerdb/datafeed/httpdownloader.go
+++ b/internal/sbomscannerdb/datafeed/httpdownloader.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -59,39 +60,35 @@ func NewHTTPDownloader() *HTTPDownloader {
 //
 // It returns the final on-disk size (post-decompression for gzipped payloads).
 func (d *HTTPDownloader) Download(ctx context.Context, url, dst string) (int64, error) {
-	tmp := tmpPath(dst)
-
-	// Best-effort cleanup: if we return without a successful rename, drop the partial.
-	// This also fires on Ctrl+C via the ctx path below.
-	renamed := false
-	defer func() {
-		if !renamed {
-			_ = os.Remove(tmp)
-		}
-	}()
-
 	resp, err := d.doRequest(ctx, url)
 	if err != nil {
 		return 0, err
 	}
-	defer resp.Body.Close()
 
+	tmp := tmpPath(dst)
 	written, err := writeStream(resp.Body, tmp)
-	if err != nil {
-		return 0, err
+	if err := errors.Join(err, resp.Body.Close()); err != nil {
+		return 0, discardPartial(tmp, err)
 	}
 
 	// Ensure exact 0600 regardless of umask.
 	if err := os.Chmod(tmp, fileMode); err != nil {
-		return 0, fmt.Errorf("chmod %s: %w", tmp, err)
+		return 0, discardPartial(tmp, fmt.Errorf("chmod %s: %w", tmp, err))
 	}
 
 	// Atomic rename lands the file in its final place.
 	if err := os.Rename(tmp, dst); err != nil {
-		return 0, fmt.Errorf("rename %s -> %s: %w", tmp, dst, err)
+		return 0, discardPartial(tmp, fmt.Errorf("rename %s -> %s: %w", tmp, dst, err))
 	}
-	renamed = true
 	return written, nil
+}
+
+// discardPartial removes the partial download at tmp and returns err joined with any removal error.
+func discardPartial(tmp string, err error) error {
+	if removeErr := os.Remove(tmp); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return errors.Join(err, fmt.Errorf("remove %s: %w", tmp, removeErr))
+	}
+	return err
 }
 
 // doRequest issues the GET and validates the response status.
@@ -108,9 +105,8 @@ func (d *HTTPDownloader) doRequest(ctx context.Context, url string) (*http.Respo
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Include a snippet of the body to make CDN errors debuggable.
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		_ = resp.Body.Close()
-		return nil, fmt.Errorf("unexpected status %s: %s", resp.Status, string(snippet))
+		snippet, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, errors.Join(fmt.Errorf("unexpected status %s: %s", resp.Status, string(snippet)), readErr, resp.Body.Close())
 	}
 	return resp, nil
 }
@@ -126,19 +122,16 @@ func writeStream(src io.Reader, tmp string) (int64, error) {
 
 	reader, gzipReader, err := maybeGunzip(src)
 	if err != nil {
-		_ = tmpFile.Close()
-		return 0, err
+		return 0, errors.Join(err, tmpFile.Close())
 	}
 
-	written, copyErr := io.Copy(tmpFile, reader)
+	written, err := io.Copy(tmpFile, reader)
+	var gzipErr error
 	if gzipReader != nil {
-		_ = gzipReader.Close()
+		gzipErr = gzipReader.Close()
 	}
-	if closeErr := tmpFile.Close(); closeErr != nil && copyErr == nil {
-		copyErr = closeErr
-	}
-	if copyErr != nil {
-		return 0, fmt.Errorf("write %s: %w", tmp, copyErr)
+	if err := errors.Join(err, gzipErr, tmpFile.Close()); err != nil {
+		return 0, fmt.Errorf("write %s: %w", tmp, err)
 	}
 	return written, nil
 }

--- a/internal/sbomscannerdb/datafeed/kev.go
+++ b/internal/sbomscannerdb/datafeed/kev.go
@@ -12,8 +12,11 @@ import (
 	"time"
 )
 
-// KEVFileName is the file name of the KEV catalog in the destination directory.
-const KEVFileName = "known_exploited_vulnerabilities.json"
+// KEVSourceFileName is the file name of the KEV catalog as downloaded from CISA.
+const KEVSourceFileName = "known_exploited_vulnerabilities.json"
+
+// KEVDBFileName is the file name of the KEV database built from the catalog.
+const KEVDBFileName = "kev.sqlite"
 
 // defaultKEVURL is the CISA KEV catalog feed.
 const defaultKEVURL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
@@ -40,23 +43,39 @@ type KEVVulnerability struct {
 	KnownRansomwareCampaignUse string   `json:"knownRansomwareCampaignUse"`
 	Notes                      string   `json:"notes"`
 	CWEs                       []string `json:"cwes"`
+
+	// raw is the entry as CISA published it, kept so the database stores
+	// fields this struct does not know yet.
+	raw json.RawMessage
 }
 
 // ParseKEVCatalog parses and sanity-checks a KEV catalog JSON document:
 // it must decode into a KEVCatalog with at least one vulnerability entry,
 // each carrying a CVE ID (the field consumers key on).
 func ParseKEVCatalog(reader io.Reader) (*KEVCatalog, error) {
-	var catalog KEVCatalog
-	if err := json.NewDecoder(reader).Decode(&catalog); err != nil {
+	var document struct {
+		KEVCatalog
+
+		Vulnerabilities []json.RawMessage `json:"vulnerabilities"`
+	}
+	if err := json.NewDecoder(reader).Decode(&document); err != nil {
 		return nil, fmt.Errorf("parse KEV catalog: %w", err)
 	}
-	if len(catalog.Vulnerabilities) == 0 {
+	if len(document.Vulnerabilities) == 0 {
 		return nil, errors.New("KEV catalog has no vulnerability entries")
 	}
-	for i, vulnerability := range catalog.Vulnerabilities {
+	catalog := document.KEVCatalog
+	catalog.Vulnerabilities = make([]KEVVulnerability, 0, len(document.Vulnerabilities))
+	for i, raw := range document.Vulnerabilities {
+		var vulnerability KEVVulnerability
+		if err := json.Unmarshal(raw, &vulnerability); err != nil {
+			return nil, fmt.Errorf("parse KEV catalog: vulnerability entry %d: %w", i, err)
+		}
 		if vulnerability.CVEID == "" {
 			return nil, fmt.Errorf("KEV catalog: vulnerability entry %d has an empty cveID", i)
 		}
+		vulnerability.raw = raw
+		catalog.Vulnerabilities = append(catalog.Vulnerabilities, vulnerability)
 	}
 	return &catalog, nil
 }
@@ -80,37 +99,33 @@ func NewKEVDownloader(httpDownloader *HTTPDownloader, logger *slog.Logger) *KEVD
 // Name is the short feed id.
 func (d *KEVDownloader) Name() string { return "kev" }
 
-// FileName is the KEV catalog's file name within the data directory.
-func (d *KEVDownloader) FileName() string { return KEVFileName }
-
-// Format is the KEV catalog's file format.
-func (d *KEVDownloader) Format() string { return "json" }
-
-// Download fetches the KEV catalog (JSON) into dir/KEVFileName
-// and validates that it parses as a usable catalog.
+// Download fetches the KEV catalog (JSON) into dir.
 func (d *KEVDownloader) Download(ctx context.Context, dir string) error {
-	dst := filepath.Join(dir, KEVFileName)
 	d.logger.InfoContext(ctx, "downloading KEV catalog", "url", d.url)
-	size, err := d.http.Download(ctx, d.url, dst)
+	size, err := d.http.Download(ctx, d.url, filepath.Join(dir, KEVSourceFileName))
 	if err != nil {
 		return fmt.Errorf("download KEV: %w", err)
 	}
-
-	catalog, err := parseKEVFile(dst)
-	if err != nil {
-		return fmt.Errorf("validate KEV: %w", err)
-	}
-
-	d.logger.InfoContext(ctx, "downloaded KEV catalog", "file", KEVFileName, "bytes", size, "entries", len(catalog.Vulnerabilities))
+	d.logger.InfoContext(ctx, "downloaded KEV catalog", "bytes", size)
 	return nil
 }
 
-// Validate parses dir/KEVFileName as a KEV catalog.
-func (d *KEVDownloader) Validate(dir string) error {
-	if _, err := parseKEVFile(filepath.Join(dir, KEVFileName)); err != nil {
-		return fmt.Errorf("validate KEV: %w", err)
+// BuildSQLite parses srcDir/KEVSourceFileName and writes dstDir/KEVDBFileName.
+// Each entry is stored as CISA published it.
+func (d *KEVDownloader) BuildSQLite(ctx context.Context, srcDir, dstDir string) (string, error) {
+	catalog, err := parseKEVFile(filepath.Join(srcDir, KEVSourceFileName))
+	if err != nil {
+		return "", fmt.Errorf("validate KEV: %w", err)
 	}
-	return nil
+	entries := make([]Entry, 0, len(catalog.Vulnerabilities))
+	for _, vulnerability := range catalog.Vulnerabilities {
+		entries = append(entries, Entry{CVE: vulnerability.CVEID, JSON: vulnerability.raw})
+	}
+	if err := writeDatabase(ctx, filepath.Join(dstDir, KEVDBFileName), entries); err != nil {
+		return "", fmt.Errorf("build KEV database: %w", err)
+	}
+	d.logger.InfoContext(ctx, "built KEV database", "file", KEVDBFileName, "entries", len(entries))
+	return KEVDBFileName, nil
 }
 
 // parseKEVFile opens the file at path and parses it as a KEV catalog.

--- a/internal/sbomscannerdb/datafeed/kev_test.go
+++ b/internal/sbomscannerdb/datafeed/kev_test.go
@@ -23,15 +23,16 @@ func TestKEVDownloader_Download(t *testing.T) {
 	d.url = srv.URL + "/known_exploited_vulnerabilities.json"
 	require.NoError(t, d.Download(context.Background(), dir))
 
-	file, err := os.Open(filepath.Join(dir, KEVFileName))
+	// Download fetches the JSON; BuildSQLite turns it into the database,
+	// storing each entry as CISA published it.
+	dbDir := t.TempDir()
+	_, err := d.BuildSQLite(context.Background(), dir, dbDir)
 	require.NoError(t, err)
-	defer file.Close()
 
-	catalog, err := ParseKEVCatalog(file)
-	require.NoError(t, err)
-	assert.Equal(t, 1, catalog.Count)
-	require.Len(t, catalog.Vulnerabilities, 1)
-	assert.Equal(t, "CVE-2021-44228", catalog.Vulnerabilities[0].CVEID)
+	var entry KEVVulnerability
+	lookupJSON(t, filepath.Join(dbDir, KEVDBFileName), "CVE-2021-44228", &entry)
+	assert.Equal(t, "Apache", entry.VendorProject)
+	assert.Equal(t, "Known", entry.KnownRansomwareCampaignUse)
 }
 
 func TestKEVDownloader_DownloadFailsOnHTTPError(t *testing.T) {
@@ -43,15 +44,12 @@ func TestKEVDownloader_DownloadFailsOnHTTPError(t *testing.T) {
 	require.Error(t, d.Download(context.Background(), t.TempDir()))
 }
 
-func TestKEVDownloader_DownloadFailsOnInvalidPayload(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("<html><body>Service temporarily unavailable</body></html>"))
-	}))
-	t.Cleanup(srv.Close)
+func TestKEVDownloader_BuildSQLiteFailsOnInvalidPayload(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, KEVSourceFileName), []byte("<html>error</html>"), 0o600))
 
 	d := NewKEVDownloader(NewHTTPDownloader(), slog.New(slog.DiscardHandler))
-	d.url = srv.URL + "/known_exploited_vulnerabilities.json"
-	err := d.Download(context.Background(), t.TempDir())
+	_, err := d.BuildSQLite(context.Background(), dir, t.TempDir())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "validate KEV")
 }

--- a/internal/sbomscannerdb/datafeed/source.go
+++ b/internal/sbomscannerdb/datafeed/source.go
@@ -5,21 +5,16 @@ import (
 	"log/slog"
 )
 
-// Source is one upstream vulnerability data feed. Implementations know how to
-// fetch and validate their feed into a data directory and describe how it
-// should be packed as an OCI layer (name + on-disk file + file format).
+// Source is one upstream vulnerability data feed.
+// Implementations fetch the upstream feed and build a SQLite database from it.
 type Source interface {
 	// Name is the short feed id (e.g. "kev"); it names the OCI layer.
 	Name() string
-	// FileName is the feed's file name within the data directory.
-	FileName() string
-	// Format is the feed's file format / extension (e.g. "json", "csv");
-	// it is carried in the layer media type.
-	Format() string
-	// Download fetches and validates the feed into dir/FileName().
+	// Download fetches the upstream feed file into dir.
 	Download(ctx context.Context, dir string) error
-	// Validate checks that dir/FileName() is a usable feed.
-	Validate(dir string) error
+	// BuildSQLite parses the upstream feed file in srcDir, writes the database into dstDir,
+	// and returns the database file name.
+	BuildSQLite(ctx context.Context, srcDir, dstDir string) (string, error)
 }
 
 // AllSources returns every data feed packed into the DB artifact.

--- a/internal/sbomscannerdb/datafeed/sqlite.go
+++ b/internal/sbomscannerdb/datafeed/sqlite.go
@@ -1,0 +1,149 @@
+package datafeed
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/stephenafamo/bob/dialect/sqlite"
+	"github.com/stephenafamo/bob/dialect/sqlite/im"
+	"github.com/stephenafamo/bob/dialect/sqlite/sm"
+	_ "modernc.org/sqlite" // sqlite driver
+)
+
+// sqliteDriver is the database/sql driver name registered by modernc.org/sqlite.
+const sqliteDriver = "sqlite"
+
+// entriesTable holds one JSON entry per CVE. Every feed database has this one table.
+const entriesTable = "entries"
+
+// schema is the layout shared by every feed database.
+const schema = `CREATE TABLE entries (cve_id TEXT PRIMARY KEY, entry TEXT NOT NULL);`
+
+// ErrNotFound reports that a CVE has no entry in a database.
+var ErrNotFound = errors.New("not found")
+
+// Entry is one row of a feed database: the CVE and its data as JSON.
+type Entry struct {
+	CVE  string
+	JSON []byte
+}
+
+// Database reads a feed database written by this package.
+type Database struct {
+	db     *sql.DB
+	lookup *sql.Stmt
+}
+
+// OpenDatabase opens the feed database at path read-only.
+// immutable tells SQLite the file cannot change while open, so it takes no locks.
+func OpenDatabase(ctx context.Context, path string) (*Database, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	db, err := sql.Open(sqliteDriver, "file:"+path+"?mode=ro&immutable=1")
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+
+	query, _, err := sqlite.Select(
+		sm.Columns("entry"),
+		sm.From(entriesTable),
+		sm.Where(sqlite.Quote("cve_id").EQ(sqlite.Arg(""))),
+	).Build(ctx)
+	if err != nil {
+		return nil, errors.Join(fmt.Errorf("build lookup query: %w", err), db.Close())
+	}
+	lookup, err := db.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, errors.Join(fmt.Errorf("prepare lookup in %s: %w", path, err), db.Close())
+	}
+	return &Database{db: db, lookup: lookup}, nil
+}
+
+// Lookup returns the JSON entry of cve, or ErrNotFound when the CVE has none.
+func (d *Database) Lookup(ctx context.Context, cve string) ([]byte, error) {
+	var entry []byte
+	err := d.lookup.QueryRowContext(ctx, cve).Scan(&entry)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("lookup %s: %w", cve, err)
+	}
+	return entry, nil
+}
+
+// Close releases the database.
+func (d *Database) Close() error {
+	if err := errors.Join(d.lookup.Close(), d.db.Close()); err != nil {
+		return fmt.Errorf("close database: %w", err)
+	}
+	return nil
+}
+
+// writeDatabase creates a fresh feed database at path with the given entries.
+// The bytes depend only on the entries: the file is new, rows are inserted sorted
+// by CVE, and VACUUM compacts the pages. An unchanged feed keeps its layer digest.
+func writeDatabase(ctx context.Context, path string, entries []Entry) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", path, err)
+	}
+	db, err := sql.Open(sqliteDriver, path)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer db.Close()
+
+	// A single writer on a throwaway file: no journal, no fsync.
+	if _, err := db.ExecContext(ctx, `PRAGMA journal_mode=OFF; PRAGMA synchronous=OFF;`); err != nil {
+		return fmt.Errorf("configure %s: %w", path, err)
+	}
+	if _, err := db.ExecContext(ctx, schema); err != nil {
+		return fmt.Errorf("create schema in %s: %w", path, err)
+	}
+
+	sorted := slices.Clone(entries)
+	slices.SortFunc(sorted, func(a, b Entry) int { return strings.Compare(a.CVE, b.CVE) })
+
+	query, _, err := sqlite.Insert(
+		im.Into(entriesTable, "cve_id", "entry"),
+		im.Values(sqlite.Arg("", "")),
+	).Build(ctx)
+	if err != nil {
+		return fmt.Errorf("build insert query: %w", err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin %s: %w", path, err)
+	}
+	insert, err := tx.PrepareContext(ctx, query)
+	if err != nil {
+		return errors.Join(fmt.Errorf("prepare insert: %w", err), tx.Rollback())
+	}
+	defer insert.Close()
+	for _, entry := range sorted {
+		if _, err := insert.ExecContext(ctx, entry.CVE, string(entry.JSON)); err != nil {
+			return errors.Join(fmt.Errorf("insert %s: %w", entry.CVE, err), tx.Rollback())
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit %s: %w", path, err)
+	}
+	if _, err := db.ExecContext(ctx, `VACUUM`); err != nil {
+		return fmt.Errorf("vacuum %s: %w", path, err)
+	}
+	// The write ran without journal or fsync, so check the result before it ships.
+	var integrity string
+	if err := db.QueryRowContext(ctx, `PRAGMA integrity_check`).Scan(&integrity); err != nil {
+		return fmt.Errorf("check %s: %w", path, err)
+	}
+	if integrity != "ok" {
+		return fmt.Errorf("check %s: %s", path, integrity)
+	}
+	return nil
+}

--- a/internal/sbomscannerdb/datafeed/sqlite_test.go
+++ b/internal/sbomscannerdb/datafeed/sqlite_test.go
@@ -1,0 +1,65 @@
+package datafeed
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabase_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "feed.sqlite")
+	entries := []Entry{
+		{CVE: "CVE-2021-44228", JSON: []byte(`{"a":1}`)},
+		{CVE: "CVE-2019-0708", JSON: []byte(`{"a":2}`)},
+	}
+	require.NoError(t, writeDatabase(context.Background(), path, entries))
+
+	db, err := OpenDatabase(context.Background(), path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	entry, err := db.Lookup(context.Background(), "CVE-2019-0708")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"a":2}`, string(entry))
+
+	_, err = db.Lookup(context.Background(), "CVE-0000-0000")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestWriteDatabase_IsReproducible(t *testing.T) {
+	// The same entries in a different order must give the same bytes.
+	entries := []Entry{
+		{CVE: "CVE-2021-44228", JSON: []byte(`{"a":1}`)},
+		{CVE: "CVE-2019-0708", JSON: []byte(`{"a":2}`)},
+	}
+	first := writeAndRead(t, entries)
+	second := writeAndRead(t, []Entry{entries[1], entries[0]})
+	assert.Equal(t, first, second)
+	assert.NotEmpty(t, first)
+}
+
+// writeAndRead writes entries into a fresh database and returns the file bytes.
+func writeAndRead(t *testing.T, entries []Entry) []byte {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "feed.sqlite")
+	require.NoError(t, writeDatabase(context.Background(), path, entries))
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return data
+}
+
+// lookupJSON returns the entry of cve in the database at path, decoded into out.
+func lookupJSON(t *testing.T, path, cve string, out any) {
+	t.Helper()
+	db, err := OpenDatabase(context.Background(), path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	entry, err := db.Lookup(context.Background(), cve)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(entry, out))
+}

--- a/internal/sbomscannerdb/db.go
+++ b/internal/sbomscannerdb/db.go
@@ -17,6 +17,10 @@ import (
 	"github.com/kubewarden/sbomscanner/internal/sbomscannerdb/oci"
 )
 
+// schemaVersion is the tag of the artifact that this worker reads.
+// It changes only when an older worker cannot read the new layout.
+const schemaVersion = 1
+
 // cacheDirName is the database directory under the worker run dir.
 const cacheDirName = "sbomscannerdb"
 
@@ -47,13 +51,14 @@ type DB struct {
 	digest string
 }
 
-// Open returns a DB for the artifact at ref, stored under runDir/sbomscannerdb.
+// Open returns a DB for the artifact at repository, tagged with the schema version.
+// The local copy lives under runDir/sbomscannerdb.
 // It does not contact the registry or open any file. The first Update does both,
 // and the databases stay open until Close.
-func Open(ref, runDir string, cfg oci.Config, logger *slog.Logger) *DB {
+func Open(repository, runDir string, cfg oci.Config, logger *slog.Logger) *DB {
 	cacheDir := filepath.Join(runDir, cacheDirName)
 	return &DB{
-		ref:      ref,
+		ref:      repository + ":" + strconv.Itoa(schemaVersion),
 		cacheDir: cacheDir,
 		local:    oci.NewStore(filepath.Join(cacheDir, ociDirName), logger),
 		remote:   oci.NewRemote(cfg, logger),

--- a/internal/sbomscannerdb/db.go
+++ b/internal/sbomscannerdb/db.go
@@ -2,9 +2,10 @@ package sbomscannerdb
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -30,7 +31,7 @@ type Record struct {
 	EPSS *storagev1alpha1.EPSS
 }
 
-// DB is the local copy of the sbomscanner database, indexed in memory by CVE.
+// DB is the local copy of the sbomscanner database, queried per CVE.
 // A nil *DB is disabled: Update does nothing and Lookup returns empty records.
 // DB is not safe for concurrent use. The worker handles one scan at a time.
 type DB struct {
@@ -40,15 +41,16 @@ type DB struct {
 	remote   *oci.Remote
 	logger   *slog.Logger
 
-	kev  map[string]storagev1alpha1.KEV
-	epss map[string]storagev1alpha1.EPSS
+	kev  *datafeed.Database
+	epss *datafeed.Database
 	// digest is the manifest digest of the loaded artifact, empty until the first load.
 	digest string
 }
 
-// New returns a DB for the artifact at ref, stored under runDir/sbomscannerdb.
-// It does not contact the registry. Call Update to load the data.
-func New(ref, runDir string, cfg oci.Config, logger *slog.Logger) *DB {
+// Open returns a DB for the artifact at ref, stored under runDir/sbomscannerdb.
+// It does not contact the registry or open any file. The first Update does both,
+// and the databases stay open until Close.
+func Open(ref, runDir string, cfg oci.Config, logger *slog.Logger) *DB {
 	cacheDir := filepath.Join(runDir, cacheDirName)
 	return &DB{
 		ref:      ref,
@@ -56,8 +58,6 @@ func New(ref, runDir string, cfg oci.Config, logger *slog.Logger) *DB {
 		local:    oci.NewStore(filepath.Join(cacheDir, ociDirName), logger),
 		remote:   oci.NewRemote(cfg, logger),
 		logger:   logger,
-		kev:      map[string]storagev1alpha1.KEV{},
-		epss:     map[string]storagev1alpha1.EPSS{},
 	}
 }
 
@@ -89,53 +89,103 @@ func (db *DB) Update(ctx context.Context) error {
 	if err := db.reload(ctx, view); err != nil {
 		return fmt.Errorf("load sbomscanner DB: %w", err)
 	}
-	db.logger.InfoContext(ctx, "sbomscanner DB loaded", "ref", db.ref, "digest", view.Digest, "kev", len(db.kev), "epss", len(db.epss), "nextUpdate", view.Annotations[oci.AnnotationNextUpdate])
+	db.logger.InfoContext(ctx, "sbomscanner DB loaded", "ref", db.ref, "digest", view.Digest, "nextUpdate", view.Annotations[oci.AnnotationNextUpdate])
 	return nil
 }
 
 // Lookup returns the record of cve, or a zero Record when there is none.
-func (db *DB) Lookup(cve string) Record {
-	if db == nil {
-		return Record{}
+func (db *DB) Lookup(ctx context.Context, cve string) (Record, error) {
+	if db == nil || db.kev == nil {
+		return Record{}, nil
 	}
 
 	var record Record
-	if kev, ok := db.kev[cve]; ok {
-		record.KEV = &kev
+	var kev datafeed.KEVVulnerability
+	found, err := lookup(ctx, db.kev, cve, &kev)
+	if err != nil {
+		return Record{}, fmt.Errorf("look up %s in KEV: %w", cve, err)
 	}
-	if epss, ok := db.epss[cve]; ok {
-		record.EPSS = &epss
+	if found {
+		record.KEV = &storagev1alpha1.KEV{
+			DateAdded:                  kev.DateAdded,
+			DueDate:                    kev.DueDate,
+			KnownRansomwareCampaignUse: storagev1alpha1.RansomwareCampaignUse(kev.KnownRansomwareCampaignUse),
+		}
 	}
-	return record
+	var epss datafeed.EPSSEntry
+	found, err = lookup(ctx, db.epss, cve, &epss)
+	if err != nil {
+		return Record{}, fmt.Errorf("look up %s in EPSS: %w", cve, err)
+	}
+	if found {
+		record.EPSS = &storagev1alpha1.EPSS{
+			Score:      strconv.FormatFloat(epss.EPSS, 'f', -1, 64),
+			Percentile: strconv.FormatFloat(epss.Percentile, 'f', -1, 64),
+			Date:       metav1.NewTime(epss.Date),
+		}
+	}
+	return record, nil
 }
 
-// reload exports the artifact in view from the local store and loads its feeds.
+// Close releases the open databases.
+func (db *DB) Close() error {
+	if db == nil {
+		return nil
+	}
+	return db.closeFeeds()
+}
+
+// reload exports the artifact in view from the local store and opens its databases.
+// On failure the previously opened databases stay in use.
 func (db *DB) reload(ctx context.Context, view oci.ManifestView) error {
 	if _, err := db.local.Export(ctx, db.ref, db.cacheDir); err != nil {
 		return fmt.Errorf("export sbomscanner DB: %w", err)
 	}
-	if err := db.load(); err != nil {
-		return err
+	kev, err := datafeed.OpenDatabase(ctx, filepath.Join(db.cacheDir, datafeed.KEVDBFileName))
+	if err != nil {
+		return fmt.Errorf("open KEV database: %w", err)
 	}
+	epss, err := datafeed.OpenDatabase(ctx, filepath.Join(db.cacheDir, datafeed.EPSSDBFileName))
+	if err != nil {
+		return errors.Join(fmt.Errorf("open EPSS database: %w", err), kev.Close())
+	}
+
+	if err := db.closeFeeds(); err != nil {
+		db.logger.WarnContext(ctx, "failed to close the previous sbomscanner DB", "error", err)
+	}
+	db.kev = kev
+	db.epss = epss
 	db.digest = view.Digest
 	return nil
 }
 
-// load parses the KEV and EPSS files from the cache dir.
-// Both feeds are part of the database, so it fails when either cannot be read.
-func (db *DB) load() error {
-	kev, err := loadKEV(filepath.Join(db.cacheDir, datafeed.KEVFileName))
-	if err != nil {
-		return err
+func (db *DB) closeFeeds() error {
+	var kevErr, epssErr error
+	if db.kev != nil {
+		kevErr = db.kev.Close()
+		db.kev = nil
 	}
-	epss, err := loadEPSS(filepath.Join(db.cacheDir, datafeed.EPSSFileName))
-	if err != nil {
-		return err
+	if db.epss != nil {
+		epssErr = db.epss.Close()
+		db.epss = nil
 	}
+	return errors.Join(kevErr, epssErr)
+}
 
-	db.kev = kev
-	db.epss = epss
-	return nil
+// lookup decodes the entry of cve from database into out.
+// It returns false when the CVE has no entry.
+func lookup(ctx context.Context, database *datafeed.Database, cve string, out any) (bool, error) {
+	entry, err := database.Lookup(ctx, cve)
+	if errors.Is(err, datafeed.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("query entry: %w", err)
+	}
+	if err := json.Unmarshal(entry, out); err != nil {
+		return false, fmt.Errorf("decode entry: %w", err)
+	}
+	return true, nil
 }
 
 // nextHorizon reads the nextUpdate annotation of view. A bad value yields the zero time,
@@ -146,48 +196,4 @@ func nextHorizon(view oci.ManifestView) time.Time {
 		return time.Time{}
 	}
 	return next
-}
-
-func loadKEV(path string) (map[string]storagev1alpha1.KEV, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return map[string]storagev1alpha1.KEV{}, fmt.Errorf("open KEV catalog %s: %w", path, err)
-	}
-	defer file.Close()
-
-	catalog, err := datafeed.ParseKEVCatalog(file)
-	if err != nil {
-		return map[string]storagev1alpha1.KEV{}, fmt.Errorf("parse KEV catalog %s: %w", path, err)
-	}
-	index := make(map[string]storagev1alpha1.KEV, len(catalog.Vulnerabilities))
-	for _, vuln := range catalog.Vulnerabilities {
-		index[vuln.CVEID] = storagev1alpha1.KEV{
-			DateAdded:                  vuln.DateAdded,
-			DueDate:                    vuln.DueDate,
-			KnownRansomwareCampaignUse: storagev1alpha1.RansomwareCampaignUse(vuln.KnownRansomwareCampaignUse),
-		}
-	}
-	return index, nil
-}
-
-func loadEPSS(path string) (map[string]storagev1alpha1.EPSS, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return map[string]storagev1alpha1.EPSS{}, fmt.Errorf("open EPSS scores %s: %w", path, err)
-	}
-	defer file.Close()
-
-	scores, err := datafeed.ParseEPSSScores(file)
-	if err != nil {
-		return map[string]storagev1alpha1.EPSS{}, fmt.Errorf("parse EPSS scores %s: %w", path, err)
-	}
-	index := make(map[string]storagev1alpha1.EPSS, len(scores.Scores))
-	for _, score := range scores.Scores {
-		index[score.CVE] = storagev1alpha1.EPSS{
-			Score:      strconv.FormatFloat(score.EPSS, 'f', -1, 64),
-			Percentile: strconv.FormatFloat(score.Percentile, 'f', -1, 64),
-			Date:       metav1.NewTime(scores.ScoreDate),
-		}
-	}
-	return index, nil
 }

--- a/internal/sbomscannerdb/db_test.go
+++ b/internal/sbomscannerdb/db_test.go
@@ -20,8 +20,11 @@ import (
 	"github.com/kubewarden/sbomscanner/internal/sbomscannerdb/oci"
 )
 
-// testRef uses a reserved host, so every registry contact fails fast.
-const testRef = "registry.invalid/kubewarden/sbomscannerdb:latest"
+// testRepository uses a reserved host, so every registry contact fails fast.
+const testRepository = "registry.invalid/kubewarden/sbomscannerdb"
+
+// testRef is the reference that Open builds from testRepository.
+const testRef = testRepository + ":1"
 
 // seedFeeds writes the KEV and EPSS databases into dir, converted from upstream
 // feeds the same way build does.
@@ -94,7 +97,7 @@ func lookupRecord(t *testing.T, db *DB, cve string) Record {
 }
 
 func newTestDB(runDir string) *DB {
-	return Open(testRef, runDir, oci.Config{}, slog.New(slog.DiscardHandler))
+	return Open(testRepository, runDir, oci.Config{}, slog.New(slog.DiscardHandler))
 }
 
 func TestLookup(t *testing.T) {

--- a/internal/sbomscannerdb/db_test.go
+++ b/internal/sbomscannerdb/db_test.go
@@ -23,7 +23,8 @@ import (
 // testRef uses a reserved host, so every registry contact fails fast.
 const testRef = "registry.invalid/kubewarden/sbomscannerdb:latest"
 
-// seedFeeds writes a KEV catalog and an EPSS feed into dir.
+// seedFeeds writes the KEV and EPSS databases into dir, converted from upstream
+// feeds the same way build does.
 // CVE-2021-44228 is in both, CVE-2019-0708 only in KEV, CVE-2020-1234 only in EPSS.
 func seedFeeds(t *testing.T, dir string) {
 	t.Helper()
@@ -37,7 +38,7 @@ func seedFeeds(t *testing.T, dir string) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.KEVFileName), kev, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.KEVSourceFileName), kev, 0o600))
 
 	var epss strings.Builder
 	fmt.Fprintf(&epss, "#model_version:v2026.07.16,score_date:%s\n", scoreDate().Format(time.RFC3339))
@@ -48,7 +49,13 @@ func seedFeeds(t *testing.T, dir string) {
 	} {
 		fmt.Fprintf(&epss, "%s,%g,%g\n", score.CVE, score.EPSS, score.Percentile)
 	}
-	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.EPSSFileName), []byte(epss.String()), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, datafeed.EPSSSourceFileName), []byte(epss.String()), 0o600))
+
+	logger := slog.New(slog.DiscardHandler)
+	for _, source := range datafeed.AllSources(datafeed.NewHTTPDownloader(), logger) {
+		_, err := source.BuildSQLite(context.Background(), dir, dir)
+		require.NoError(t, err)
+	}
 }
 
 // scoreDate is the score_date of the seeded EPSS feed.
@@ -68,8 +75,8 @@ func buildArtifact(t *testing.T, runDir string, interval time.Duration) oci.Arti
 	dataDir := t.TempDir()
 	seedFeeds(t, dataDir)
 	layers := []oci.Layer{
-		{Name: "kev", FileName: datafeed.KEVFileName, MediaType: oci.DataLayerMediaType("kev", "json")},
-		{Name: "epss", FileName: datafeed.EPSSFileName, MediaType: oci.DataLayerMediaType("epss", "csv")},
+		{Name: "kev", FileName: datafeed.KEVDBFileName, MediaType: oci.DataLayerMediaType("kev")},
+		{Name: "epss", FileName: datafeed.EPSSDBFileName, MediaType: oci.DataLayerMediaType("epss")},
 	}
 	logger := slog.New(slog.DiscardHandler)
 	store := oci.NewStore(filepath.Join(runDir, cacheDirName, ociDirName), logger)
@@ -78,11 +85,19 @@ func buildArtifact(t *testing.T, runDir string, interval time.Duration) oci.Arti
 	return built
 }
 
-func newTestDB(runDir string) *DB {
-	return New(testRef, runDir, oci.Config{}, slog.New(slog.DiscardHandler))
+// lookupRecord runs Lookup and fails the test on an error.
+func lookupRecord(t *testing.T, db *DB, cve string) Record {
+	t.Helper()
+	record, err := db.Lookup(context.Background(), cve)
+	require.NoError(t, err)
+	return record
 }
 
-func TestLookup_AfterUpdate(t *testing.T) {
+func newTestDB(runDir string) *DB {
+	return Open(testRef, runDir, oci.Config{}, slog.New(slog.DiscardHandler))
+}
+
+func TestLookup(t *testing.T) {
 	dir := t.TempDir()
 	buildArtifact(t, dir, 24*time.Hour)
 	db := newTestDB(dir)
@@ -90,11 +105,13 @@ func TestLookup_AfterUpdate(t *testing.T) {
 
 	tests := []struct {
 		name string
+		db   *DB
 		cve  string
 		want Record
 	}{
 		{
 			name: "KEV and EPSS",
+			db:   db,
 			cve:  "CVE-2021-44228",
 			want: Record{
 				KEV:  log4jKEV(),
@@ -103,31 +120,40 @@ func TestLookup_AfterUpdate(t *testing.T) {
 		},
 		{
 			name: "KEV only",
+			db:   db,
 			cve:  "CVE-2019-0708",
 			want: Record{KEV: &storagev1alpha1.KEV{DateAdded: "2021-11-03", DueDate: "2022-05-03", KnownRansomwareCampaignUse: storagev1alpha1.RansomwareCampaignUseUnknown}},
 		},
 		{
 			name: "EPSS only",
+			db:   db,
 			cve:  "CVE-2020-1234",
 			want: Record{EPSS: &storagev1alpha1.EPSS{Score: "0.01", Percentile: "0.5", Date: metav1.NewTime(scoreDate())}},
 		},
 		{
 			name: "unknown CVE",
+			db:   db,
 			cve:  "CVE-0000-0000",
+			want: Record{},
+		},
+		{
+			name: "nil DB",
+			db:   nil,
+			cve:  "CVE-2021-44228",
 			want: Record{},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.want, db.Lookup(test.cve))
+			assert.Equal(t, test.want, lookupRecord(t, test.db, test.cve))
 		})
 	}
 }
 
-func TestLookup_NilStoreIsNoOp(t *testing.T) {
+func TestNilDB(t *testing.T) {
 	var db *DB
-	assert.Equal(t, Record{}, db.Lookup("CVE-2021-44228"))
 	assert.NoError(t, db.Update(context.Background()))
+	assert.NoError(t, db.Close())
 }
 
 func TestUpdate_LoadsFromLocalStoreWhileFresh(t *testing.T) {
@@ -139,9 +165,9 @@ func TestUpdate_LoadsFromLocalStoreWhileFresh(t *testing.T) {
 	require.NoError(t, db.Update(context.Background()))
 
 	assert.Equal(t, built.Digest, db.digest)
-	assert.Equal(t, log4jKEV(), db.Lookup("CVE-2021-44228").KEV)
-	assert.FileExists(t, filepath.Join(dir, cacheDirName, datafeed.KEVFileName))
-	assert.FileExists(t, filepath.Join(dir, cacheDirName, datafeed.EPSSFileName))
+	assert.Equal(t, log4jKEV(), lookupRecord(t, db, "CVE-2021-44228").KEV)
+	assert.FileExists(t, filepath.Join(dir, cacheDirName, datafeed.KEVDBFileName))
+	assert.FileExists(t, filepath.Join(dir, cacheDirName, datafeed.EPSSDBFileName))
 }
 
 func TestUpdate_StaleLocalStoreIsNotUsedWhenRegistryUnreachable(t *testing.T) {
@@ -154,14 +180,14 @@ func TestUpdate_StaleLocalStoreIsNotUsedWhenRegistryUnreachable(t *testing.T) {
 	require.Error(t, db.Update(context.Background()))
 
 	assert.Empty(t, db.digest)
-	assert.Equal(t, Record{}, db.Lookup("CVE-2021-44228"))
+	assert.Equal(t, Record{}, lookupRecord(t, db, "CVE-2021-44228"))
 }
 
 func TestUpdate_StaleBrokenLocalCopyIsPulledAgain(t *testing.T) {
 	dir := t.TempDir()
 	buildArtifact(t, dir, time.Nanosecond)
 	cacheDir := filepath.Join(dir, cacheDirName)
-	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, datafeed.KEVFileName), []byte("not json"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, datafeed.KEVDBFileName), []byte("not sqlite"), 0o600))
 
 	// The local copy is stale and broken. Update must reach the pull
 	// instead of failing on the local parse.
@@ -179,24 +205,52 @@ func TestUpdate_FailsWithoutLocalStore(t *testing.T) {
 	require.Error(t, db.Update(context.Background()))
 
 	assert.Empty(t, db.digest)
-	assert.Equal(t, Record{}, db.Lookup("CVE-2021-44228"))
+	assert.Equal(t, Record{}, lookupRecord(t, db, "CVE-2021-44228"))
 }
 
-func TestLoad_FailsWhenOneFeedIsMissing(t *testing.T) {
+func TestReload_FailsWhenOneFeedIsMissing(t *testing.T) {
 	dir := t.TempDir()
-	cacheDir := filepath.Join(dir, cacheDirName)
-	require.NoError(t, os.MkdirAll(cacheDir, 0o700))
-	seedFeeds(t, cacheDir)
-	require.NoError(t, os.Remove(filepath.Join(cacheDir, datafeed.EPSSFileName)))
+	built := buildArtifact(t, dir, 24*time.Hour)
 	db := newTestDB(dir)
+	require.NoError(t, db.Update(context.Background()))
 
-	require.Error(t, db.load())
-	assert.Equal(t, Record{}, db.Lookup("CVE-2021-44228"))
+	// A broken artifact must not replace the databases that are open.
+	broken := buildBrokenArtifact(t, dir)
+	require.Error(t, db.reload(context.Background(), broken))
+	assert.Equal(t, built.Digest, db.digest)
+	assert.Equal(t, log4jKEV(), lookupRecord(t, db, "CVE-2021-44228").KEV)
 }
 
-func TestLoad_FailsWhenNoFeeds(t *testing.T) {
-	db := newTestDB(t.TempDir())
-	require.Error(t, db.load())
+func TestClose_ReleasesTheDatabases(t *testing.T) {
+	dir := t.TempDir()
+	buildArtifact(t, dir, 24*time.Hour)
+	db := newTestDB(dir)
+	require.NoError(t, db.Update(context.Background()))
+
+	require.NoError(t, db.Close())
+	assert.Nil(t, db.kev)
+	assert.Nil(t, db.epss)
+	assert.Equal(t, Record{}, lookupRecord(t, db, "CVE-2021-44228"))
+}
+
+// buildBrokenArtifact overwrites the local store with an artifact whose EPSS layer
+// is not a database and returns its manifest view.
+func buildBrokenArtifact(t *testing.T, runDir string) oci.ManifestView {
+	t.Helper()
+	dataDir := t.TempDir()
+	seedFeeds(t, dataDir)
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, datafeed.EPSSDBFileName), []byte("not sqlite"), 0o600))
+	layers := []oci.Layer{
+		{Name: "kev", FileName: datafeed.KEVDBFileName, MediaType: oci.DataLayerMediaType("kev")},
+		{Name: "epss", FileName: datafeed.EPSSDBFileName, MediaType: oci.DataLayerMediaType("epss")},
+	}
+	logger := slog.New(slog.DiscardHandler)
+	store := oci.NewStore(filepath.Join(runDir, cacheDirName, ociDirName), logger)
+	_, err := oci.NewBuilder(store, logger, "").Build(context.Background(), testRef, dataDir, layers, 24*time.Hour)
+	require.NoError(t, err)
+	view, err := store.Inspect(context.Background(), testRef)
+	require.NoError(t, err)
+	return view
 }
 
 func TestNextHorizon(t *testing.T) {

--- a/internal/sbomscannerdb/oci/artifact.go
+++ b/internal/sbomscannerdb/oci/artifact.go
@@ -31,7 +31,7 @@ const (
 	// data-layer media type (see DataLayerMediaType), so layers can be
 	// recognized by shape without enumerating each source.
 	dataLayerMediaTypePrefix = "application/vnd.sbomscanner.db."
-	dataLayerMediaTypeSuffix = "+gzip"
+	dataLayerMediaTypeSuffix = ".v1.sqlite+tar+gzip"
 
 	// AnnotationLastUpdate records when the artifact was last rebuilt and pushed.
 	AnnotationLastUpdate = "io.kubewarden.sbomscanner.db.lastUpdate"
@@ -77,11 +77,11 @@ func (w UpdateWindow) annotations() map[string]string {
 	}
 }
 
-// DataLayerMediaType builds the media type of a DB data layer from the source
-// name and its file format, e.g. DataLayerMediaType("kev", "json") yields
-// "application/vnd.sbomscanner.db.kev.v1.json+gzip".
-func DataLayerMediaType(name, format string) string {
-	return dataLayerMediaTypePrefix + name + ".v1." + format + dataLayerMediaTypeSuffix
+// DataLayerMediaType builds the media type of a DB data layer from the feed name.
+// Every layer is a SQLite database packed as tar.gz, so DataLayerMediaType("kev")
+// yields "application/vnd.sbomscanner.db.kev.v1.sqlite+tar+gzip".
+func DataLayerMediaType(name string) string {
+	return dataLayerMediaTypePrefix + name + dataLayerMediaTypeSuffix
 }
 
 // isDataLayerMediaType reports whether mediaType is a DB data layer, matching

--- a/internal/sbomscannerdb/oci/manifest_test.go
+++ b/internal/sbomscannerdb/oci/manifest_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestDataLayerMediaType(t *testing.T) {
-	assert.Equal(t, "application/vnd.sbomscanner.db.kev.v1.json+gzip", DataLayerMediaType("kev", "json"))
-	assert.Equal(t, "application/vnd.sbomscanner.db.epss.v1.csv+gzip", DataLayerMediaType("epss", "csv"))
+	assert.Equal(t, "application/vnd.sbomscanner.db.kev.v1.sqlite+tar+gzip", DataLayerMediaType("kev"))
+	assert.Equal(t, "application/vnd.sbomscanner.db.epss.v1.sqlite+tar+gzip", DataLayerMediaType("epss"))
 }
 
 func TestIsDataLayerMediaType(t *testing.T) {
-	assert.True(t, isDataLayerMediaType(DataLayerMediaType("gtfobins", "json")))
-	assert.True(t, isDataLayerMediaType(DataLayerMediaType("kev", "json")))
-	assert.True(t, isDataLayerMediaType(DataLayerMediaType("epss", "csv")))
+	assert.True(t, isDataLayerMediaType(DataLayerMediaType("gtfobins")))
+	assert.True(t, isDataLayerMediaType(DataLayerMediaType("kev")))
+	assert.True(t, isDataLayerMediaType(DataLayerMediaType("epss")))
 
 	assert.False(t, isDataLayerMediaType(ArtifactType))
 	assert.False(t, isDataLayerMediaType("application/vnd.oci.image.layer.v1.tar+gzip"))

--- a/internal/sbomscannerdb/oci/store_test.go
+++ b/internal/sbomscannerdb/oci/store_test.go
@@ -34,8 +34,8 @@ func writeTestData(t *testing.T) (string, []Layer) {
 	t.Helper()
 	dataDir := t.TempDir()
 	layers := []Layer{
-		{Name: "kev", FileName: "kev.json", MediaType: DataLayerMediaType("kev", "json")},
-		{Name: "epss", FileName: "epss.csv", MediaType: DataLayerMediaType("epss", "csv")},
+		{Name: "kev", FileName: "kev.json", MediaType: DataLayerMediaType("kev")},
+		{Name: "epss", FileName: "epss.csv", MediaType: DataLayerMediaType("epss")},
 	}
 	for _, layer := range layers {
 		require.NoError(t, os.WriteFile(filepath.Join(dataDir, layer.FileName), []byte("data for "+layer.FileName), 0o600))
@@ -109,7 +109,7 @@ func TestBuild_RetagsExistingContent(t *testing.T) {
 
 func TestBuild_FailsOnMissingDataFile(t *testing.T) {
 	storeDir := filepath.Join(t.TempDir(), "store")
-	layers := []Layer{{Name: "epss", FileName: "missing.csv", MediaType: DataLayerMediaType("epss", "csv")}}
+	layers := []Layer{{Name: "epss", FileName: "missing.csv", MediaType: DataLayerMediaType("epss")}}
 	_, err := NewBuilder(NewStore(storeDir, slog.New(slog.DiscardHandler)), slog.New(slog.DiscardHandler), "").build(context.Background(), testRef, t.TempDir(), layers, testWindow())
 	require.Error(t, err)
 }
@@ -118,7 +118,7 @@ func TestBuild_FailsOnEmptyDataFile(t *testing.T) {
 	dataDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "empty.csv"), nil, 0o600))
 
-	layers := []Layer{{Name: "epss", FileName: "empty.csv", MediaType: DataLayerMediaType("epss", "csv")}}
+	layers := []Layer{{Name: "epss", FileName: "empty.csv", MediaType: DataLayerMediaType("epss")}}
 	_, err := NewBuilder(NewStore(filepath.Join(t.TempDir(), "store"), slog.New(slog.DiscardHandler)), slog.New(slog.DiscardHandler), "").build(context.Background(), testRef, dataDir, layers, testWindow())
 	require.Error(t, err)
 }
@@ -156,8 +156,8 @@ func assertViewMatchesBuild(t *testing.T, view ManifestView, built Artifact) {
 
 	require.Len(t, view.Layers, 2)
 	mediaTypes := []string{view.Layers[0].MediaType, view.Layers[1].MediaType}
-	assert.Contains(t, mediaTypes, DataLayerMediaType("kev", "json"))
-	assert.Contains(t, mediaTypes, DataLayerMediaType("epss", "csv"))
+	assert.Contains(t, mediaTypes, DataLayerMediaType("kev"))
+	assert.Contains(t, mediaTypes, DataLayerMediaType("epss"))
 	for _, layer := range view.Layers {
 		assert.NotEmpty(t, layer.Digest)
 		assert.Positive(t, layer.Size)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -24,7 +24,7 @@ var (
 	controllerImage = "ghcr.io/kubewarden/sbomscanner/controller:latest"
 	storageImage    = "ghcr.io/kubewarden/sbomscanner/storage:latest"
 	// sbomscannerDBRepository is a fixed test asset whose KEV and EPSS entries cover the scanned test images.
-	sbomscannerDBRepository = "ghcr.io/kubewarden/sbomscanner/test-assets/sbomscannerdb:1"
+	sbomscannerDBRepository = "ghcr.io/kubewarden/sbomscanner/test-assets/sbomscannerdb"
 	certManagerNamespace    = "cert-manager"
 	certManagerVersion      = "v1.18.2"
 	cnpgNamespace           = "cnpg-system"


### PR DESCRIPTION
## Description
Fix #1313

The sbomscanner vulnerability database now carries one SQLite database per feed.
Each layer is a SQLite file packed as tar.gz, with the media type `application/vnd.sbomscanner.db.<feed>.v1.sqlite+tar+gzip`.
Every database has one table, `entries`, with the CVE id as the key and the feed entry as JSON.
The artifact keeps the `:1` tag and the `lastUpdate` and `nextUpdate` annotations on the manifest.

`sbomscannerdb build` downloads the upstream feeds, builds one database per feed, and packs them.
`--data-dir` builds from local feed files instead.

The worker opens the databases from its local copy and queries them per CVE.
It no longer loads the feeds in memory.
The databases stay open until the worker stops, and are replaced when a new artifact is pulled.

## Test

Unit tests cover the database build, the lookup, and the worker update path.
Handler tests run against the test asset `ghcr.io/kubewarden/sbomscanner/test-assets/sbomscannerdb:1`.
An e2e assertion checks the KEV and EPSS fields in a report.

## Additional Information

The build is reproducible.
Entries are inserted in sorted order, the journal is off, and the file is compacted with `VACUUM`.
The same feed files give the same bytes.

### Tradeoff

None.

### Potential improvement

None.

## Checklist

- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
- [ ] I have updated the documentation via a pull request in [docs](https://github.com/kubewarden/docs/tree/main/docs/sbom-scanner) repository.
